### PR TITLE
Add sign out sidebar action with reusable component

### DIFF
--- a/application-system/src/main/java/com/group_9/project/AccountAddressPage.java
+++ b/application-system/src/main/java/com/group_9/project/AccountAddressPage.java
@@ -25,7 +25,7 @@ public class AccountAddressPage extends Template {
         BaseFrameSetup.applyAppIcon(this);
         BackgroundPanel background = BaseFrameSetup.setupCompleteFrame(this, 3);
         
-        JPanel sidebar = createSidebar();
+        JPanel sidebar = AccountSidebarUtil.createSidebar(this, "My Address");
         background.add(sidebar);
 
         JPanel content = new RoundedComponents.RoundedShadowPanel(25, 4);
@@ -39,74 +39,7 @@ public class AccountAddressPage extends Template {
         SwingUtilities.invokeLater(() -> background.requestFocusInWindow());
     }
 
-    private JPanel createSidebar() { //sidebar
-        JPanel sidebar = new JPanel();
-        sidebar.setLayout(new BoxLayout(sidebar, BoxLayout.Y_AXIS));
-        sidebar.setBounds(50, 125, 200, 300);
-        sidebar.setBackground(new Color(0, 0, 0, 0));
-        sidebar.setOpaque(false); 
-
-        JLabel title = new JLabel("MY ACCOUNT");
-        title.setFont(FontUtil.getOutfitBoldFont(25f));
-        title.setForeground(new Color(42, 2, 67, 255));
-        title.setBorder(BorderFactory.createEmptyBorder(10, 10, 10, 10));
-        title.setOpaque(false);
-        sidebar.add(title);
-        sidebar.add(Box.createVerticalStrut(15));
-
-        String[] items = {"My Details", "My Address", "My Subscriptions"}; //sidebar selection
-        Color selectedColor = new Color(132, 0, 159, 255);
-        Color defaultColor = new Color(22, 6, 48, 128);
-        Color hoverColor = new Color(62, 10, 118);
-
-        for (String item : items) {
-            Color color = item.equals("My Address") ? selectedColor : defaultColor;
-            JLabel label = makeSidebarLabel("   " + item, color);
-            label.setCursor(Cursor.getPredefinedCursor(Cursor.HAND_CURSOR));
-            
-            label.setOpaque(false);
-
-            label.addMouseListener(new java.awt.event.MouseAdapter() {
-                public void mouseClicked(java.awt.event.MouseEvent e) {
-                    switch (item) {
-                        case "My Details" -> {
-                            new AccountDetailsPage().setVisible(true);
-                            dispose();
-                        }
-                        case "My Address" -> {
-                            new AccountAddressPage().setVisible(true);
-                            dispose();
-                        }
-                        case "My Subscriptions" -> {
-                            new AccountSubsPage().setVisible(true);
-                            dispose();
-                        }
-                    }
-                }
-
-                public void mouseEntered(java.awt.event.MouseEvent e) {
-                    if (!item.equals("My Address")) {
-                        label.setForeground(hoverColor);
-                        label.setOpaque(false);
-                        label.repaint();
-                    }
-                }
-
-                public void mouseExited(java.awt.event.MouseEvent e) {
-                    if (!item.equals("My Address")) {
-                        label.setForeground(defaultColor);
-                        label.setOpaque(false);
-                        label.repaint();
-                    }
-                }
-            });
-
-            sidebar.add(label);
-            sidebar.add(Box.createVerticalStrut(30));
-        }
-
-        return sidebar;
-    }
+    
 
 
     private JPanel createDetailsContainer() {
@@ -468,13 +401,7 @@ public class AccountAddressPage extends Template {
     }
 
 
-    private JLabel makeSidebarLabel(String text, Color color) {
-        JLabel label = new JLabel(text);
-        label.setFont(FontUtil.getOutfitFont(18f));
-        label.setForeground(color);
-        label.setOpaque(false);
-        return label;
-    }
+    
 
     public static void main(String[] args) {
         SwingUtilities.invokeLater(() -> new AccountAddressPage().setVisible(true));

--- a/application-system/src/main/java/com/group_9/project/AccountDetailsPage.java
+++ b/application-system/src/main/java/com/group_9/project/AccountDetailsPage.java
@@ -29,7 +29,7 @@ public class AccountDetailsPage extends Template {
         BaseFrameSetup.applyAppIcon(this);
         BackgroundPanel background = BaseFrameSetup.setupCompleteFrame(this, 3);
 
-        JPanel sidebar = createSidebar();
+        JPanel sidebar = AccountSidebarUtil.createSidebar(this, "My Details");
         background.add(sidebar);
 
         JPanel content = new RoundedComponents.RoundedShadowPanel(25, 4);
@@ -46,74 +46,7 @@ public class AccountDetailsPage extends Template {
         });
     }
 
-    private JPanel createSidebar() { //sidebar
-        JPanel sidebar = new JPanel();
-        sidebar.setLayout(new BoxLayout(sidebar, BoxLayout.Y_AXIS));
-        sidebar.setBounds(50, 125, 200, 300);
-        sidebar.setBackground(new Color(0, 0, 0, 0));
-        sidebar.setOpaque(false); 
-
-        JLabel title = new JLabel("MY ACCOUNT");
-        title.setFont(FontUtil.getOutfitBoldFont(25f));
-        title.setForeground(new Color(42, 2, 67, 255));
-        title.setBorder(BorderFactory.createEmptyBorder(10, 10, 10, 10));
-        title.setOpaque(false);
-        sidebar.add(title);
-        sidebar.add(Box.createVerticalStrut(15));
-
-        String[] items = {"My Details", "My Address", "My Subscriptions"};
-        Color selectedColor = new Color(132, 0, 159, 255);
-        Color defaultColor = new Color(22, 6, 48, 128);
-        Color hoverColor = new Color(62, 10, 118);
-
-        for (String item : items) {
-            Color color = item.equals("My Details") ? selectedColor : defaultColor;
-            JLabel label = makeSidebarLabel("   " + item, color);
-            label.setCursor(Cursor.getPredefinedCursor(Cursor.HAND_CURSOR));
-            
-            label.setOpaque(false);
-
-            label.addMouseListener(new java.awt.event.MouseAdapter() {
-                public void mouseClicked(java.awt.event.MouseEvent e) {
-                    switch (item) {
-                        case "My Details" -> {
-                            new AccountDetailsPage().setVisible(true);
-                            dispose();
-                        }
-                        case "My Address" -> {
-                            new AccountAddressPage().setVisible(true);
-                            dispose();
-                        }
-                        case "My Subscriptions" -> {
-                            new AccountSubsPage().setVisible(true);
-                            dispose();
-                        }
-                    }
-                }
-                
-                public void mouseEntered(java.awt.event.MouseEvent e) {
-                    if (!item.equals("My Details")) {
-                        label.setForeground(hoverColor);
-                        label.setOpaque(false);
-                        label.repaint();
-                    }
-                }
-
-                public void mouseExited(java.awt.event.MouseEvent e) {
-                    if (!item.equals("My Details")) {
-                        label.setForeground(defaultColor);
-                        label.setOpaque(false);
-                        label.repaint();
-                    }
-                }
-            });
-
-            sidebar.add(label);
-            sidebar.add(Box.createVerticalStrut(30));
-        }
-
-        return sidebar;
-    }
+    
 
 
     private JPanel createDetailsContainer() {
@@ -485,13 +418,7 @@ public class AccountDetailsPage extends Template {
         textFields.get(8).setText(UserApplicationData.get("MaidenName"));
     }
 
-    private JLabel makeSidebarLabel(String text, Color color) {
-        JLabel label = new JLabel(text);
-        label.setFont(FontUtil.getOutfitFont(18f));
-        label.setForeground(color);
-        label.setOpaque(false);
-        return label;
-    }
+    
 
     private void styleButton(JButton btn) {
         btn.setBackground(new Color(45, 2, 67));

--- a/application-system/src/main/java/com/group_9/project/AccountSubsPage.java
+++ b/application-system/src/main/java/com/group_9/project/AccountSubsPage.java
@@ -14,7 +14,7 @@ public class AccountSubsPage extends Template {
         BaseFrameSetup.applyAppIcon(this);
         BackgroundPanel background = BaseFrameSetup.setupCompleteFrame(this, 3);
 
-        JPanel sidebar = createSidebar();
+        JPanel sidebar = AccountSidebarUtil.createSidebar(this, "My Subscriptions");
         background.add(sidebar);
 
         JPanel content = new RoundedComponents.RoundedShadowPanel(25, 4);
@@ -27,63 +27,7 @@ public class AccountSubsPage extends Template {
         SwingUtilities.invokeLater(() -> background.requestFocusInWindow());
     }
 
-    JPanel createSidebar() { //sidebar
-        JPanel sidebar = new JPanel();
-        sidebar.setLayout(new BoxLayout(sidebar, BoxLayout.Y_AXIS));
-        sidebar.setBounds(50, 125, 200, 300);
-        sidebar.setBackground(new Color(0, 0, 0, 0));
-        sidebar.setOpaque(false);
-
-        JLabel title = new JLabel("MY ACCOUNT");
-        title.setFont(FontUtil.getOutfitBoldFont(25f));
-        title.setForeground(new Color(42, 2, 67, 255));
-        title.setBorder(BorderFactory.createEmptyBorder(10, 10, 10, 10));
-        sidebar.add(title);
-        sidebar.add(Box.createVerticalStrut(15));
-
-        String[] items = {"My Details", "My Address", "My Subscriptions"};
-        Color selectedColor = new Color(132, 0, 159, 255);
-        Color defaultColor = new Color(22, 6, 48, 128);
-        Color hoverColor = new Color(62, 10, 118);
-
-        for (String item : items) {
-            Color color = item.equals("My Subscriptions") ? selectedColor : defaultColor;
-            JLabel label = makeSidebarLabel("   " + item, color);
-            label.setCursor(Cursor.getPredefinedCursor(Cursor.HAND_CURSOR));
-
-            label.addMouseListener(new java.awt.event.MouseAdapter() {
-                public void mouseClicked(java.awt.event.MouseEvent e) {
-                    switch (item) {
-                        case "My Details" -> {
-                            new AccountDetailsPage().setVisible(true);
-                            dispose();
-                        }
-                        case "My Address" -> {
-                            new AccountAddressPage().setVisible(true);
-                            dispose();
-                        }
-                        case "My Subscriptions" -> {
-                            new AccountSubsPage().setVisible(true);
-                            dispose();
-                        }
-                    }
-                }
-
-                public void mouseEntered(java.awt.event.MouseEvent e) {
-                    if (!item.equals("My Subscriptions")) label.setForeground(hoverColor);
-                }
-
-                public void mouseExited(java.awt.event.MouseEvent e) {
-                    if (!item.equals("My Subscriptions")) label.setForeground(defaultColor);
-                }
-            });
-
-            sidebar.add(label);
-            sidebar.add(Box.createVerticalStrut(30));
-        }
-
-        return sidebar;
-    }
+    
 
 
     private JPanel createDetailsContainer() {
@@ -240,13 +184,7 @@ public class AccountSubsPage extends Template {
         return applicantBox;
     }
 
-    JLabel makeSidebarLabel(String text, Color color) {
-        JLabel label = new JLabel(text);
-        label.setFont(FontUtil.getOutfitFont(18f));
-        label.setForeground(color);
-        label.setOpaque(false);
-        return label;
-    }
+    
 
     public static void main(String[] args) {
         SwingUtilities.invokeLater(() -> new AccountSubsPage().setVisible(true));

--- a/application-system/src/main/java/com/group_9/project/utils/AccountSidebarUtil.java
+++ b/application-system/src/main/java/com/group_9/project/utils/AccountSidebarUtil.java
@@ -1,0 +1,103 @@
+package com.group_9.project.utils;
+
+import com.group_9.project.*;
+import com.group_9.project.session.UserApplicationData;
+
+import javax.swing.*;
+import java.awt.*;
+
+/** Utility for creating the sidebar in account pages. */
+public final class AccountSidebarUtil {
+    private AccountSidebarUtil() {}
+
+    private static final Color SELECTED_COLOR = new Color(132, 0, 159, 255);
+    private static final Color DEFAULT_COLOR  = new Color(22, 6, 48, 128);
+    private static final Color HOVER_COLOR    = new Color(62, 10, 118);
+
+    public static JPanel createSidebar(JFrame frame, String activeItem) {
+        JPanel sidebar = new JPanel();
+        sidebar.setLayout(new BoxLayout(sidebar, BoxLayout.Y_AXIS));
+        sidebar.setBounds(50, 125, 200, 300);
+        sidebar.setBackground(new Color(0, 0, 0, 0));
+        sidebar.setOpaque(false);
+
+        JLabel title = new JLabel("MY ACCOUNT");
+        title.setFont(FontUtil.getOutfitBoldFont(25f));
+        title.setForeground(new Color(42, 2, 67, 255));
+        title.setBorder(BorderFactory.createEmptyBorder(10, 10, 10, 10));
+        title.setOpaque(false);
+        sidebar.add(title);
+        sidebar.add(Box.createVerticalStrut(15));
+
+        String[] items = {"My Details", "My Address", "My Subscriptions", "Sign Out"};
+        for (String item : items) {
+            Color color = item.equals(activeItem) ? SELECTED_COLOR : DEFAULT_COLOR;
+            JLabel label = createLabel("   " + item, color);
+            label.setCursor(Cursor.getPredefinedCursor(Cursor.HAND_CURSOR));
+
+            label.addMouseListener(new java.awt.event.MouseAdapter() {
+                @Override public void mouseClicked(java.awt.event.MouseEvent e) {
+                    switch (item) {
+                        case "My Details" -> {
+                            if (!activeItem.equals("My Details")) {
+                                new AccountDetailsPage().setVisible(true);
+                                frame.dispose();
+                            }
+                        }
+                        case "My Address" -> {
+                            if (!activeItem.equals("My Address")) {
+                                new AccountAddressPage().setVisible(true);
+                                frame.dispose();
+                            }
+                        }
+                        case "My Subscriptions" -> {
+                            if (!activeItem.equals("My Subscriptions")) {
+                                new AccountSubsPage().setVisible(true);
+                                frame.dispose();
+                            }
+                        }
+                        case "Sign Out" -> {
+                            boolean confirm = CustomDialogUtil.showStyledConfirmDialog(
+                                frame,
+                                "Sign Out",
+                                "Are you sure you want to sign out?"
+                            );
+                            if (confirm) {
+                                UserApplicationData.clear();
+                                new Homepage().setVisible(true);
+                                frame.dispose();
+                            }
+                        }
+                    }
+                }
+
+                @Override public void mouseEntered(java.awt.event.MouseEvent e) {
+                    if (!item.equals(activeItem)) {
+                        label.setForeground(HOVER_COLOR);
+                        label.repaint();
+                    }
+                }
+
+                @Override public void mouseExited(java.awt.event.MouseEvent e) {
+                    if (!item.equals(activeItem)) {
+                        label.setForeground(DEFAULT_COLOR);
+                        label.repaint();
+                    }
+                }
+            });
+
+            sidebar.add(label);
+            sidebar.add(Box.createVerticalStrut(30));
+        }
+
+        return sidebar;
+    }
+
+    private static JLabel createLabel(String text, Color color) {
+        JLabel label = new JLabel(text);
+        label.setFont(FontUtil.getOutfitFont(18f));
+        label.setForeground(color);
+        label.setOpaque(false);
+        return label;
+    }
+}

--- a/application-system/src/main/java/com/group_9/project/utils/CustomDialogUtil.java
+++ b/application-system/src/main/java/com/group_9/project/utils/CustomDialogUtil.java
@@ -230,4 +230,103 @@ public class CustomDialogUtil {
         overlay.add(dialogPanel);
         overlay.setVisible(true);
     }
+    public static boolean showStyledConfirmDialog(JFrame parent, String title, String message) {
+        final int WIDTH = 440;
+        final int HEIGHT = 260;
+        final int BORDER_RADIUS = 30;
+        final boolean[] result = { false };
+
+        JDialog overlay = new JDialog(parent, true);
+        overlay.setUndecorated(true);
+        overlay.setBackground(new Color(0, 0, 0, 80));
+        overlay.setLayout(null);
+        overlay.setSize(Toolkit.getDefaultToolkit().getScreenSize());
+        overlay.setLocationRelativeTo(null);
+
+        JPanel dialogPanel = new JPanel(null) {
+            @Override protected void paintComponent(Graphics g) {
+                Graphics2D g2 = (Graphics2D) g.create();
+                g2.setRenderingHint(RenderingHints.KEY_ANTIALIASING, RenderingHints.VALUE_ANTIALIAS_ON);
+                int arc = BORDER_RADIUS;
+                g2.setColor(Color.WHITE);
+                g2.fillRoundRect(1, 1, getWidth() - 2, getHeight() - 2, arc, arc);
+                g2.setColor(new Color(124, 58, 189));
+                g2.setStroke(new BasicStroke(2f));
+                g2.drawRoundRect(1, 1, getWidth() - 3, getHeight() - 3, arc, arc);
+                g2.dispose();
+            }
+        };
+        dialogPanel.setOpaque(false);
+        dialogPanel.setBounds((overlay.getWidth() - WIDTH) / 2, (overlay.getHeight() - HEIGHT) / 2, WIDTH, HEIGHT);
+
+        JPanel contentPanel = new JPanel();
+        contentPanel.setLayout(new BoxLayout(contentPanel, BoxLayout.Y_AXIS));
+        contentPanel.setBackground(new Color(0, 0, 0, 0));
+        contentPanel.setBounds(0, 0, WIDTH, HEIGHT);
+        contentPanel.setBorder(BorderFactory.createEmptyBorder(25, 40, 30, 40));
+        contentPanel.setOpaque(false);
+
+        ImageIcon infoIcon = new ImageIcon(CustomDialogUtil.class.getResource("/icons/info.png"));
+        Image scaledImage = infoIcon.getImage().getScaledInstance(50, 50, Image.SCALE_SMOOTH);
+        JLabel icon = new JLabel(new ImageIcon(scaledImage));
+        icon.setAlignmentX(Component.CENTER_ALIGNMENT);
+
+        JLabel titleLabel = new JLabel(title);
+        titleLabel.setFont(FontUtil.getOutfitBoldFont(20f));
+        titleLabel.setForeground(new Color(43, 2, 67));
+        titleLabel.setAlignmentX(Component.CENTER_ALIGNMENT);
+
+        JLabel messageLabel = new JLabel("<html><div style='text-align: center;'>" + message + "</div></html>");
+        messageLabel.setFont(FontUtil.getInterFont(14f));
+        messageLabel.setForeground(new Color(50, 46, 46));
+        messageLabel.setAlignmentX(Component.CENTER_ALIGNMENT);
+        messageLabel.setHorizontalAlignment(SwingConstants.CENTER);
+
+        JPanel buttons = new JPanel();
+        buttons.setOpaque(false);
+
+        RoundedComponents.RoundedButton yesButton = new RoundedComponents.RoundedButton("Yes", 25);
+        yesButton.setFont(FontUtil.getOutfitBoldFont(15f));
+        yesButton.setForeground(Color.WHITE);
+        yesButton.setBackground(new Color(160, 108, 213));
+        yesButton.setPreferredSize(new Dimension(110, 42));
+        yesButton.setMaximumSize(new Dimension(110, 42));
+        yesButton.setBorder(new RoundedComponents.RoundedBorder(25));
+
+        RoundedComponents.RoundedButton noButton = new RoundedComponents.RoundedButton("No", 25);
+        noButton.setFont(FontUtil.getOutfitBoldFont(15f));
+        noButton.setForeground(Color.WHITE);
+        noButton.setBackground(new Color(160, 108, 213));
+        noButton.setPreferredSize(new Dimension(110, 42));
+        noButton.setMaximumSize(new Dimension(110, 42));
+        noButton.setBorder(new RoundedComponents.RoundedBorder(25));
+
+        ButtonHoverEffect.apply(yesButton, new Color(138, 74, 194), Color.WHITE, new Color(160, 108, 213), Color.WHITE, new Color(189, 160, 224), new Color(160, 108, 213));
+        ButtonHoverEffect.apply(noButton,  new Color(138, 74, 194), Color.WHITE, new Color(160, 108, 213), Color.WHITE, new Color(189, 160, 224), new Color(160, 108, 213));
+
+        yesButton.addActionListener((ActionEvent e) -> { result[0] = true; overlay.dispose(); });
+        noButton.addActionListener((ActionEvent e) -> overlay.dispose());
+
+        buttons.add(yesButton);
+        buttons.add(Box.createRigidArea(new Dimension(20, 0)));
+        buttons.add(noButton);
+        buttons.setAlignmentX(Component.CENTER_ALIGNMENT);
+
+        JRootPane rootPane = overlay.getRootPane();
+        rootPane.setDefaultButton(yesButton);
+
+        contentPanel.add(Box.createRigidArea(new Dimension(0, 15)));
+        contentPanel.add(icon);
+        contentPanel.add(Box.createRigidArea(new Dimension(0, 12)));
+        contentPanel.add(titleLabel);
+        contentPanel.add(Box.createRigidArea(new Dimension(0, 8)));
+        contentPanel.add(messageLabel);
+        contentPanel.add(Box.createRigidArea(new Dimension(0, 20)));
+        contentPanel.add(buttons);
+
+        dialogPanel.add(contentPanel);
+        overlay.add(dialogPanel);
+        overlay.setVisible(true);
+        return result[0];
+    }
 }


### PR DESCRIPTION
## Summary
- add `AccountSidebarUtil` utility to generate account sidebars
- update account pages to use util and include Sign Out option
- add styled confirmation dialog for sign out

## Testing
- `mvn -q -DskipTests=false test` *(fails: `mvn` not found)*

------
https://chatgpt.com/codex/tasks/task_e_6853319ae0fc832c839b140f5fd2dc95