### PR TITLE
Add unsubscribe support to account subscriptions

### DIFF
--- a/application-system/src/main/java/com/group_9/project/AccountSubsPage.java
+++ b/application-system/src/main/java/com/group_9/project/AccountSubsPage.java
@@ -4,6 +4,7 @@ import com.group_9.project.database.AccountService;
 import com.group_9.project.database.AccountService.Subscription;
 import com.group_9.project.session.UserApplicationData;
 import com.group_9.project.utils.*;
+import com.group_9.project.database.PaymentDao;
 import javax.swing.*;
 import java.awt.*;
 import java.sql.SQLException;
@@ -89,6 +90,7 @@ public class AccountSubsPage extends Template {
                     String.format("₱%,.2f", s.planDetails.serviceFee),
                     s.planDetails.installFee,
                     s.applicationNo,
+                    s.planDetails.planId,
                     s.dateSubmitted
                 );
                 container.add(card);
@@ -102,11 +104,12 @@ public class AccountSubsPage extends Template {
             for (Subscription s : subs) {
                 // each card will auto–size via GridLayout
                 JPanel card = createWhiteBox(
-                    0, 0, 
+                    0, 0,
                     s.planDetails.servicePlan,
                     String.format("₱%,.2f", s.planDetails.serviceFee),
                     s.planDetails.installFee,
                     s.applicationNo,
+                    s.planDetails.planId,
                     s.dateSubmitted
                 );
                 grid.add(card);
@@ -131,7 +134,7 @@ public class AccountSubsPage extends Template {
     
 
     JPanel createWhiteBox(int x, int y, String product, String monthlyFee, String installFee,
-                                  String appNo, String submittedDate) {
+                                  String appNo, String planId, String submittedDate) {
         JPanel applicantBox = new JPanel(null) {
             protected void paintComponent(Graphics g) {
                 Graphics2D g2 = (Graphics2D) g.create();
@@ -181,7 +184,61 @@ public class AccountSubsPage extends Template {
         details.setBounds(20, 130, 300, 75);
         applicantBox.add(details);
 
+        RoundedComponents.RoundedButton unsubBtn =
+                new RoundedComponents.RoundedButton("UNSUBSCRIBE", 20);
+        unsubBtn.setBounds(230, 170, 130, 35);
+        unsubBtn.setFont(FontUtil.getOutfitBoldFont(14f));
+        ButtonHoverEffect.apply(
+                unsubBtn,
+                new Color(62, 10, 118), Color.WHITE,
+                new Color(42, 2, 67), Color.WHITE,
+                new Color(62, 10, 118), new Color(42, 2, 67)
+        );
+        unsubBtn.addActionListener(e -> onUnsubscribe(appNo, planId));
+        applicantBox.add(unsubBtn);
+
         return applicantBox;
+    }
+
+    private void onUnsubscribe(String appNo, String planId) {
+        boolean confirm = CustomDialogUtil.showStyledConfirmDialog(
+                this,
+                "Unsubscribe",
+                "Are you sure you want to unsubscribe from this plan?"
+        );
+        if (!confirm) return;
+
+        new SwingWorker<Boolean, Void>() {
+            @Override protected Boolean doInBackground() {
+                try {
+                    new PaymentDao().deletePayment(appNo, planId);
+                    return true;
+                } catch (SQLException ex) {
+                    ex.printStackTrace();
+                    return false;
+                }
+            }
+
+            @Override protected void done() {
+                boolean ok = false;
+                try { ok = get(); } catch (Exception ignored) {}
+                if (ok) {
+                    CustomDialogUtil.showStyledInfoDialog(
+                            AccountSubsPage.this,
+                            "Unsubscribed",
+                            "Your subscription has been removed."
+                    );
+                    new AccountSubsPage().setVisible(true);
+                    dispose();
+                } else {
+                    CustomDialogUtil.showStyledErrorDialog(
+                            AccountSubsPage.this,
+                            "Database Error",
+                            "Failed to unsubscribe. Please try again."
+                    );
+                }
+            }
+        }.execute();
     }
 
     

--- a/application-system/src/main/java/com/group_9/project/database/PaymentDao.java
+++ b/application-system/src/main/java/com/group_9/project/database/PaymentDao.java
@@ -64,4 +64,22 @@ public class PaymentDao {
         String option   = UserApplicationData.get("paymentOption");
         insertPayments(appNo, planIds, option);
     }
+
+    /**
+     * Deletes one payment row for the given application and plan ID.
+     *
+     * @param applicationNo the application number
+     * @param planId        the plan ID
+     * @throws SQLException if the delete fails
+     */
+    public void deletePayment(String applicationNo, String planId) throws SQLException {
+        String sql = "DELETE FROM tbl_payment WHERE application_no = ? AND plan_ID = ?";
+        try (Connection conn = DatabaseConnection.getConnection();
+             PreparedStatement ps = conn.prepareStatement(sql)) {
+
+            ps.setString(1, applicationNo);
+            ps.setString(2, planId);
+            ps.executeUpdate();
+        }
+    }
 }


### PR DESCRIPTION
## Summary
- add DAO method to remove subscription from `tbl_payment`
- include plan ID when rendering subscription panels
- show **UNSUBSCRIBE** button per subscription and update DB on confirmation

## Testing
- `mvn -q test` *(fails: `mvn` not found)*

------
https://chatgpt.com/codex/tasks/task_e_685800d2aae0832c934a6afd5b932ed0