### PR TITLE
Add unsubscribe deletion with scrolling fix

### DIFF
--- a/application-system/src/main/java/com/group_9/project/AccountSubsPage.java
+++ b/application-system/src/main/java/com/group_9/project/AccountSubsPage.java
@@ -4,6 +4,7 @@ import com.group_9.project.database.AccountService;
 import com.group_9.project.database.AccountService.Subscription;
 import com.group_9.project.session.UserApplicationData;
 import com.group_9.project.utils.*;
+import com.group_9.project.database.PaymentDao;
 import javax.swing.*;
 import java.awt.*;
 import java.sql.SQLException;
@@ -89,7 +90,8 @@ public class AccountSubsPage extends Template {
                     String.format("₱%,.2f", s.planDetails.serviceFee),
                     s.planDetails.installFee,
                     s.applicationNo,
-                    s.dateSubmitted
+                    s.dateSubmitted,
+                    s.planDetails.planId
                 );
                 container.add(card);
             }
@@ -98,16 +100,21 @@ public class AccountSubsPage extends Template {
             // 1) Build a JPanel with GridLayout(0,2)
             JPanel grid = new JPanel(new GridLayout(0, 2, hGap, vGap));
             grid.setOpaque(false);
+            int rows = (int) Math.ceil(subs.size() / 2.0);
+            int gridW = 2 * boxW + hGap;
+            int gridH = rows * boxH + (rows - 1) * vGap;
+            grid.setPreferredSize(new Dimension(gridW, gridH));
     
             for (Subscription s : subs) {
                 // each card will auto–size via GridLayout
                 JPanel card = createWhiteBox(
-                    0, 0, 
+                    0, 0,
                     s.planDetails.servicePlan,
                     String.format("₱%,.2f", s.planDetails.serviceFee),
                     s.planDetails.installFee,
                     s.applicationNo,
-                    s.dateSubmitted
+                    s.dateSubmitted,
+                    s.planDetails.planId
                 );
                 grid.add(card);
             }
@@ -131,7 +138,7 @@ public class AccountSubsPage extends Template {
     
 
     JPanel createWhiteBox(int x, int y, String product, String monthlyFee, String installFee,
-                                  String appNo, String submittedDate) {
+                                  String appNo, String submittedDate, String planId) {
         JPanel applicantBox = new JPanel(null) {
             protected void paintComponent(Graphics g) {
                 Graphics2D g2 = (Graphics2D) g.create();
@@ -149,6 +156,7 @@ public class AccountSubsPage extends Template {
             }
         };
         applicantBox.setBounds(x, y, 380, 220);
+        applicantBox.setPreferredSize(new Dimension(380, 220));
 
         JLabel header = new JLabel("Product and Service");
         header.setFont(FontUtil.getOutfitFont(17f));
@@ -180,6 +188,53 @@ public class AccountSubsPage extends Template {
         details.setFont(FontUtil.getOutfitBoldFont(12f));
         details.setBounds(20, 130, 300, 75);
         applicantBox.add(details);
+
+        RoundedComponents.RoundedButton unsubBtn = new RoundedComponents.RoundedButton("UNSUBSCRIBE", 20);
+        unsubBtn.setFont(FontUtil.getOutfitBoldFont(14f));
+        unsubBtn.setBounds(230, 170, 130, 35);
+        unsubBtn.setBackground(new Color(98, 60, 187));
+        unsubBtn.setForeground(Color.WHITE);
+        unsubBtn.setBorderColor(new Color(98, 60, 187));
+        ButtonHoverEffect.apply(
+                unsubBtn,
+                new Color(75, 39, 143), Color.WHITE,
+                new Color(98, 60, 187), Color.WHITE,
+                new Color(120, 90, 200), new Color(98, 60, 187)
+        );
+        unsubBtn.addActionListener(e -> {
+            boolean confirm = CustomDialogUtil.showStyledConfirmDialog(
+                    AccountSubsPage.this,
+                    "Unsubscribe",
+                    "Are you sure you want to unsubscribe from this plan?"
+            );
+            if (!confirm) return;
+            try {
+                boolean deleted = new PaymentDao().deletePayment(appNo, planId);
+                if (deleted) {
+                    CustomDialogUtil.showStyledInfoDialog(
+                            AccountSubsPage.this,
+                            "Unsubscribed",
+                            "Plan removed from your subscriptions."
+                    );
+                    new AccountSubsPage().setVisible(true);
+                    AccountSubsPage.this.dispose();
+                } else {
+                    CustomDialogUtil.showStyledErrorDialog(
+                            AccountSubsPage.this,
+                            "Not Found",
+                            "Subscription could not be removed."
+                    );
+                }
+            } catch (Exception ex) {
+                ex.printStackTrace();
+                CustomDialogUtil.showStyledErrorDialog(
+                        AccountSubsPage.this,
+                        "Database Error",
+                        "Failed to remove subscription."
+                );
+            }
+        });
+        applicantBox.add(unsubBtn);
 
         return applicantBox;
     }

--- a/application-system/src/main/java/com/group_9/project/database/PaymentDao.java
+++ b/application-system/src/main/java/com/group_9/project/database/PaymentDao.java
@@ -16,6 +16,11 @@ public class PaymentDao {
         VALUES(?, ?, ?)
         """;
 
+    private static final String DELETE_SQL = """
+        DELETE FROM tbl_payment
+         WHERE application_no = ? AND plan_ID = ?
+        """;
+
     /**
      * Inserts one payment row per plan ID for the given application.
      *
@@ -63,5 +68,30 @@ public class PaymentDao {
         String planIds  = UserApplicationData.get("selectedPlanIDs");
         String option   = UserApplicationData.get("paymentOption");
         insertPayments(appNo, planIds, option);
+    }
+
+    /**
+     * Deletes a payment row for the given application number and plan ID.
+     *
+     * @param applicationNo the application number
+     * @param planId        the plan ID to remove
+     * @return true if a row was deleted
+     * @throws SQLException if the delete fails
+     */
+    public boolean deletePayment(String applicationNo, String planId) throws SQLException {
+        if (applicationNo == null || applicationNo.isBlank()) {
+            throw new IllegalArgumentException("applicationNo must not be blank");
+        }
+        if (planId == null || planId.isBlank()) {
+            throw new IllegalArgumentException("planId must not be blank");
+        }
+
+        try (Connection conn = DatabaseConnection.getConnection();
+             PreparedStatement ps = conn.prepareStatement(DELETE_SQL)) {
+            ps.setString(1, applicationNo.trim());
+            ps.setString(2, planId.trim());
+            int count = ps.executeUpdate();
+            return count > 0;
+        }
     }
 }


### PR DESCRIPTION
## Summary
- add `deletePayment` method to `PaymentDao` for removing a plan
- allow scrolling when there are five or more subscriptions and size cards correctly
- show an `UNSUBSCRIBE` button on each subscription panel with confirmation dialog

## Testing
- `mvn -q -f application-system/pom.xml test` *(fails: mvn command not found)*

------
https://chatgpt.com/codex/tasks/task_e_685800d2aae0832c934a6afd5b932ed0