### PR TITLE
Fix hover cursor and centralize custom scrollbar

### DIFF
--- a/application-system/src/main/java/com/group_9/project/AboutUsPage.java
+++ b/application-system/src/main/java/com/group_9/project/AboutUsPage.java
@@ -5,7 +5,7 @@ import com.group_9.project.utils.*;
 import java.awt.*;
 import java.awt.geom.Ellipse2D;
 import javax.swing.*;
-import javax.swing.plaf.basic.BasicScrollBarUI;
+import com.group_9.project.utils.CustomScrollBarUI;
 
 import java.awt.event.MouseAdapter;
 import java.awt.event.MouseEvent;
@@ -183,43 +183,6 @@ public class AboutUsPage extends Template {
     }
 
 
-    private static class CustomScrollBarUI extends BasicScrollBarUI {
-        private static final Color THUMB_COLOR = new Color(42, 2, 67);
-
-        @Override
-        protected void configureScrollBarColors() {
-            this.thumbColor = THUMB_COLOR;
-            this.trackColor = new Color(0, 0, 0, 0);
-        }
-
-        @Override
-        protected JButton createDecreaseButton(int orientation) {
-            return createZeroButton();
-        }
-
-        @Override
-        protected JButton createIncreaseButton(int orientation) {
-            return createZeroButton();
-        }
-
-        private JButton createZeroButton() {
-            JButton button = new JButton();
-            button.setPreferredSize(new Dimension(0, 0));
-            return button;
-        }
-
-        @Override
-        protected void paintThumb(Graphics g, JComponent c, Rectangle thumbBounds) {
-            if (!scrollbar.isEnabled() || thumbBounds.isEmpty()) return;
-            Graphics2D g2 = (Graphics2D) g.create();
-            g2.setColor(THUMB_COLOR);
-            g2.fillRoundRect(thumbBounds.x, thumbBounds.y, thumbBounds.width, thumbBounds.height, 10, 10);
-            g2.dispose();
-        }
-
-        @Override
-        protected void paintTrack(Graphics g, JComponent c, Rectangle trackBounds) {}
-    }
 
     public static void main(String[] args) {
         SwingUtilities.invokeLater(() -> new AboutUsPage().setVisible(true));

--- a/application-system/src/main/java/com/group_9/project/AccountAddressPage.java
+++ b/application-system/src/main/java/com/group_9/project/AccountAddressPage.java
@@ -23,6 +23,7 @@ public class AccountAddressPage extends Template {
 
     public AccountAddressPage() {
         BaseFrameSetup.applyAppIcon(this);
+        setDefaultCloseOperation(JFrame.DISPOSE_ON_CLOSE);
         BackgroundPanel background = BaseFrameSetup.setupCompleteFrame(this, 3);
         
         JPanel sidebar = AccountSidebarUtil.createSidebar(this, "My Address");

--- a/application-system/src/main/java/com/group_9/project/AccountDetailsPage.java
+++ b/application-system/src/main/java/com/group_9/project/AccountDetailsPage.java
@@ -27,6 +27,7 @@ public class AccountDetailsPage extends Template {
 
     public AccountDetailsPage() {
         BaseFrameSetup.applyAppIcon(this);
+        setDefaultCloseOperation(JFrame.DISPOSE_ON_CLOSE);
         BackgroundPanel background = BaseFrameSetup.setupCompleteFrame(this, 3);
 
         JPanel sidebar = AccountSidebarUtil.createSidebar(this, "My Details");

--- a/application-system/src/main/java/com/group_9/project/AccountSubsPage.java
+++ b/application-system/src/main/java/com/group_9/project/AccountSubsPage.java
@@ -13,6 +13,7 @@ import java.util.List;
 public class AccountSubsPage extends Template {
     public AccountSubsPage() {
         BaseFrameSetup.applyAppIcon(this);
+        setDefaultCloseOperation(JFrame.DISPOSE_ON_CLOSE);
         BackgroundPanel background = BaseFrameSetup.setupCompleteFrame(this, 3);
 
         JPanel sidebar = AccountSidebarUtil.createSidebar(this, "My Subscriptions");
@@ -195,6 +196,7 @@ public class AccountSubsPage extends Template {
         unsubBtn.setBackground(new Color(98, 60, 187));
         unsubBtn.setForeground(Color.WHITE);
         unsubBtn.setBorderColor(new Color(98, 60, 187));
+        unsubBtn.setCursor(Cursor.getPredefinedCursor(Cursor.HAND_CURSOR));
         ButtonHoverEffect.apply(
                 unsubBtn,
                 new Color(75, 39, 143), Color.WHITE,

--- a/application-system/src/main/java/com/group_9/project/AddConfirm.java
+++ b/application-system/src/main/java/com/group_9/project/AddConfirm.java
@@ -5,7 +5,7 @@ import com.group_9.project.session.UserApplicationData;
 import com.group_9.project.utils.*;
 
 import javax.swing.*;
-import javax.swing.plaf.basic.BasicScrollBarUI;
+import com.group_9.project.utils.CustomScrollBarUI;
 import javax.swing.text.AbstractDocument;
 import javax.swing.text.JTextComponent;
 import java.awt.*;
@@ -525,32 +525,6 @@ public class AddConfirm extends JFrame {
         }
     }
 
-    private static class CustomScrollBarUI extends BasicScrollBarUI {
-        private static final Color THUMB_COLOR = new Color(42, 2, 67);
-
-        @Override protected void configureScrollBarColors() {
-            thumbColor = THUMB_COLOR;
-            trackColor = new Color(0, 0, 0, 0);
-        }
-
-        @Override protected JButton createDecreaseButton(int orientation) { return createZeroButton(); }
-        @Override protected JButton createIncreaseButton(int orientation) { return createZeroButton(); }
-
-        private JButton createZeroButton() {
-            JButton btn = new JButton();
-            btn.setPreferredSize(new Dimension(0, 0));
-            return btn;
-        }
-
-        @Override protected void paintThumb(Graphics g, JComponent c, Rectangle thumbBounds) {
-            if (!scrollbar.isEnabled() || thumbBounds.isEmpty()) return;
-            Graphics2D g2 = (Graphics2D) g.create();
-            g2.setColor(THUMB_COLOR);
-            g2.fillRoundRect(thumbBounds.x, thumbBounds.y, thumbBounds.width, thumbBounds.height, 10, 10);
-            g2.dispose();
-        }
-        @Override protected void paintTrack(Graphics g, JComponent c, Rectangle trackBounds) {}
-    }
 
     private static class RoundedScrollContainer extends JPanel {
         private final int radius;

--- a/application-system/src/main/java/com/group_9/project/PlansPage.java
+++ b/application-system/src/main/java/com/group_9/project/PlansPage.java
@@ -4,7 +4,7 @@ import com.group_9.project.session.UserApplicationData;
 import com.group_9.project.utils.*;
 
 import javax.swing.*;
-import javax.swing.plaf.basic.BasicScrollBarUI;
+import com.group_9.project.utils.CustomScrollBarUI;
 import java.awt.*;
 
 public class PlansPage extends JFrame {
@@ -213,45 +213,6 @@ public class PlansPage extends JFrame {
         return card;
     }
 
-    private static class CustomScrollBarUI extends BasicScrollBarUI {
-        private static final Color THUMB_COLOR = new Color(42, 2, 67);
-
-        @Override
-        protected void configureScrollBarColors() {
-            this.thumbColor = THUMB_COLOR;
-            this.trackColor = new Color(0, 0, 0, 0);
-        }
-
-        @Override
-        protected JButton createDecreaseButton(int orientation) {
-            return createZeroButton();
-        }
-
-        @Override
-        protected JButton createIncreaseButton(int orientation) {
-            return createZeroButton();
-        }
-
-        private JButton createZeroButton() {
-            JButton button = new JButton();
-            button.setPreferredSize(new Dimension(0, 0));
-            return button;
-        }
-
-        @Override
-        protected void paintThumb(Graphics g, JComponent c, Rectangle thumbBounds) {
-            if (!scrollbar.isEnabled() || thumbBounds.isEmpty()) return;
-            Graphics2D g2 = (Graphics2D) g.create();
-            g2.setColor(THUMB_COLOR);
-            g2.fillRoundRect(thumbBounds.x, thumbBounds.y, thumbBounds.width, thumbBounds.height, 10, 10);
-            g2.dispose();
-        }
-
-        @Override
-        protected void paintTrack(Graphics g, JComponent c, Rectangle trackBounds) {
-            // No track painting
-        }
-    }
 
     public static void main(String[] args) {
         SwingUtilities.invokeLater(PlansPage::new);

--- a/application-system/src/main/java/com/group_9/project/SignUp5.java
+++ b/application-system/src/main/java/com/group_9/project/SignUp5.java
@@ -5,7 +5,7 @@ import com.group_9.project.session.UserApplicationData;
 import com.group_9.project.utils.*;
 
 import javax.swing.*;
-import javax.swing.plaf.basic.BasicScrollBarUI;
+import com.group_9.project.utils.CustomScrollBarUI;
 import javax.swing.text.AbstractDocument;
 import javax.swing.text.JTextComponent;
 
@@ -378,43 +378,6 @@ public class SignUp5 extends JFrame {
         }
     }
 
-    private static class CustomScrollBarUI extends BasicScrollBarUI {
-        private static final Color CLR_THUMB = new Color(42, 2, 67);
-
-        @Override
-        protected void configureScrollBarColors() {
-            thumbColor = CLR_THUMB;
-            trackColor = new Color(0, 0, 0, 0);
-        }
-
-        @Override
-        protected JButton createDecreaseButton(int intOrientation) {
-            return createZeroButton();
-        }
-
-        @Override
-        protected JButton createIncreaseButton(int intOrientation) {
-            return createZeroButton();
-        }
-
-        private JButton createZeroButton() {
-            JButton cmdButton = new JButton();
-            cmdButton.setPreferredSize(new Dimension(0, 0));
-            return cmdButton;
-        }
-
-        @Override
-        protected void paintThumb(Graphics g, JComponent ctlComponent, Rectangle recThumbBounds) {
-            if (!scrollbar.isEnabled() || recThumbBounds.isEmpty()) return;
-            Graphics2D g2d = (Graphics2D) g.create();
-            g2d.setColor(CLR_THUMB);
-            g2d.fillRoundRect(recThumbBounds.x, recThumbBounds.y, recThumbBounds.width, recThumbBounds.height, 10, 10);
-            g2d.dispose();
-        }
-
-        @Override
-        protected void paintTrack(Graphics g, JComponent ctlComponent, Rectangle recTrackBounds) {}
-    }
 
     private static class RoundedScrollContainer extends JPanel {
         private final int intRadius;

--- a/application-system/src/main/java/com/group_9/project/utils/AccountSidebarUtil.java
+++ b/application-system/src/main/java/com/group_9/project/utils/AccountSidebarUtil.java
@@ -40,20 +40,26 @@ public final class AccountSidebarUtil {
                     switch (item) {
                         case "My Details" -> {
                             if (!activeItem.equals("My Details")) {
-                                new AccountDetailsPage().setVisible(true);
-                                frame.dispose();
+                                SwingUtilities.invokeLater(() -> {
+                                    new AccountDetailsPage().setVisible(true);
+                                    frame.dispose();
+                                });
                             }
                         }
                         case "My Address" -> {
                             if (!activeItem.equals("My Address")) {
-                                new AccountAddressPage().setVisible(true);
-                                frame.dispose();
+                                SwingUtilities.invokeLater(() -> {
+                                    new AccountAddressPage().setVisible(true);
+                                    frame.dispose();
+                                });
                             }
                         }
                         case "My Subscriptions" -> {
                             if (!activeItem.equals("My Subscriptions")) {
-                                new AccountSubsPage().setVisible(true);
-                                frame.dispose();
+                                SwingUtilities.invokeLater(() -> {
+                                    new AccountSubsPage().setVisible(true);
+                                    frame.dispose();
+                                });
                             }
                         }
                         case "Sign Out" -> {

--- a/application-system/src/main/java/com/group_9/project/utils/CustomScrollBarUI.java
+++ b/application-system/src/main/java/com/group_9/project/utils/CustomScrollBarUI.java
@@ -1,0 +1,46 @@
+package com.group_9.project.utils;
+
+import javax.swing.*;
+import javax.swing.plaf.basic.BasicScrollBarUI;
+import java.awt.*;
+
+/** Reusable scrollbar UI with rounded thumb styling. */
+public class CustomScrollBarUI extends BasicScrollBarUI {
+    private static final Color THUMB_COLOR = new Color(42, 2, 67);
+
+    @Override
+    protected void configureScrollBarColors() {
+        thumbColor = THUMB_COLOR;
+        trackColor = new Color(0, 0, 0, 0);
+    }
+
+    @Override
+    protected JButton createDecreaseButton(int orientation) {
+        return createZeroButton();
+    }
+
+    @Override
+    protected JButton createIncreaseButton(int orientation) {
+        return createZeroButton();
+    }
+
+    private JButton createZeroButton() {
+        JButton button = new JButton();
+        button.setPreferredSize(new Dimension(0, 0));
+        return button;
+    }
+
+    @Override
+    protected void paintThumb(Graphics g, JComponent c, Rectangle thumbBounds) {
+        if (!scrollbar.isEnabled() || thumbBounds.isEmpty()) return;
+        Graphics2D g2 = (Graphics2D) g.create();
+        g2.setColor(THUMB_COLOR);
+        g2.fillRoundRect(thumbBounds.x, thumbBounds.y, thumbBounds.width, thumbBounds.height, 10, 10);
+        g2.dispose();
+    }
+
+    @Override
+    protected void paintTrack(Graphics g, JComponent c, Rectangle trackBounds) {
+        // Do not paint track
+    }
+}


### PR DESCRIPTION
## Summary
- add reusable `CustomScrollBarUI` utility
- use the new scrollbar UI in AboutUsPage, PlansPage, AddConfirm and SignUp5
- ensure unsubscribe button shows hand cursor
- handle navigation disposal in `AccountSidebarUtil`
- avoid exiting app by setting account pages to `DISPOSE_ON_CLOSE`

## Testing
- `mvn -q -f application-system/pom.xml test` *(fails: mvn not found)*

------
https://chatgpt.com/codex/tasks/task_e_68580bafcee8832c8923c7abcf653fbf