### PR TITLE
Refactor pages to use Reddick naming

### DIFF
--- a/application-system/src/main/java/com/group_9/project/AccountDetailsPage.java
+++ b/application-system/src/main/java/com/group_9/project/AccountDetailsPage.java
@@ -19,31 +19,31 @@ import com.group_9.project.utils.RoundedComponents.*;
 
 public class AccountDetailsPage extends Template {
     
-    private boolean isEditMode = false;
-    private JButton actionButton;
-    private List<JTextField> textFields = new ArrayList<>();
-    private List<JComboBox<String>> comboBoxes = new ArrayList<>();
-    private JTextField passwordField;
+    private boolean boolEditMode = false;
+    private JButton cmdAction;
+    private List<JTextField> lstTextFields = new ArrayList<>();
+    private List<JComboBox<String>> lstComboBoxes = new ArrayList<>();
+    private JTextField txtPasswordField;
 
     public AccountDetailsPage() {
         BaseFrameSetup.applyAppIcon(this);
         setDefaultCloseOperation(JFrame.DISPOSE_ON_CLOSE);
-        BackgroundPanel background = BaseFrameSetup.setupCompleteFrame(this, 3);
+        BackgroundPanel pnlBackground = BaseFrameSetup.setupCompleteFrame(this, 3);
 
-        JPanel sidebar = AccountSidebarUtil.createSidebar(this, "My Details");
-        background.add(sidebar);
+        JPanel pnlSidebar = AccountSidebarUtil.createSidebar(this, "My Details");
+        pnlBackground.add(pnlSidebar);
 
-        JPanel content = new RoundedComponents.RoundedShadowPanel(25, 4);
-        content.setBounds(290, 150, 1020, 720);
-        background.add(content);
+        JPanel pnlContent = new RoundedComponents.RoundedShadowPanel(25, 4);
+        pnlContent.setBounds(290, 150, 1020, 720);
+        pnlBackground.add(pnlContent);
 
-        JPanel detailsContainer = createDetailsContainer();
-        content.add(detailsContainer);
+        JPanel pnlDetailsContainer = createDetailsContainer();
+        pnlContent.add(pnlDetailsContainer);
 
         populateFromSession();
         
         SwingUtilities.invokeLater(() -> {
-            background.requestFocusInWindow();
+            pnlBackground.requestFocusInWindow();
         });
     }
 
@@ -51,93 +51,93 @@ public class AccountDetailsPage extends Template {
 
 
     private JPanel createDetailsContainer() {
-        JPanel detailsContainer = new JPanel(null);
-        detailsContainer.setBackground(new Color(0, 0, 0, 0));
-        detailsContainer.setBounds(0, 0, 1250, 700);
-        detailsContainer.setOpaque(false);
+        JPanel pnlDetailsContainer = new JPanel(null);
+        pnlDetailsContainer.setBackground(new Color(0, 0, 0, 0));
+        pnlDetailsContainer.setBounds(0, 0, 1250, 700);
+        pnlDetailsContainer.setOpaque(false);
     
-        JLabel titleLabel = new JLabel("MY DETAILS");
-        titleLabel.setFont(FontUtil.getOutfitBoldFont(26f));
-        titleLabel.setForeground(new Color(42, 2, 67, 255));
-        titleLabel.setBounds(70, 50, 300, 30);
-        detailsContainer.add(titleLabel);
+        JLabel lblTitle = new JLabel("MY DETAILS");
+        lblTitle.setFont(FontUtil.getOutfitBoldFont(26f));
+        lblTitle.setForeground(new Color(42, 2, 67, 255));
+        lblTitle.setBounds(70, 50, 300, 30);
+        pnlDetailsContainer.add(lblTitle);
     
-        JLabel sectionLabel = new JLabel("PERSONAL INFORMATION");
-        sectionLabel.setFont(FontUtil.getOutfitFont(16f));
-        sectionLabel.setBounds(70, 100, 300, 20);
-        detailsContainer.add(sectionLabel);
+        JLabel lblSection = new JLabel("PERSONAL INFORMATION");
+        lblSection.setFont(FontUtil.getOutfitFont(16f));
+        lblSection.setBounds(70, 100, 300, 20);
+        pnlDetailsContainer.add(lblSection);
     
-        JSeparator sep = new JSeparator();
-        sep.setBounds(70, 130, 880, 1);
-        sep.setForeground(new Color(180, 180, 180));
-        detailsContainer.add(sep);
+        JSeparator sepSeparator = new JSeparator();
+        sepSeparator.setBounds(70, 130, 880, 1);
+        sepSeparator.setForeground(new Color(180, 180, 180));
+        pnlDetailsContainer.add(sepSeparator);
     
-        String[] leftLabels = { "USERNAME", "PASSWORD", "EMAIL ADDRESS", "MOBILE NO. / TEL. NO." };
-        String[] rightLabels = { "FULL NAME", "BIRTHDAY", "GENDER", "CIVIL STATUS", "NATIONALITY", "NAME OF SPOUSE (IF MARRIED)", "FULL MOTHER'S MAIDEN NAME" };
+        String[] arrLeftLabels = { "USERNAME", "PASSWORD", "EMAIL ADDRESS", "MOBILE NO. / TEL. NO." };
+        String[] arrRightLabels = { "FULL NAME", "BIRTHDAY", "GENDER", "CIVIL STATUS", "NATIONALITY", "NAME OF SPOUSE (IF MARRIED)", "FULL MOTHER'S MAIDEN NAME" };
     
-        int yLeft = 150;
-        for (int i = 0; i < leftLabels.length; i++) {
-            JLabel label = new JLabel(leftLabels[i]);
-            label.setFont(FontUtil.getOutfitBoldFont(13f));
-            label.setForeground(new Color(42, 2, 67));
-            label.setBounds(95, yLeft, 200, 40);
-            detailsContainer.add(label);
+        int intYLeft = 150;
+        for (int i = 0; i < arrLeftLabels.length; i++) {
+            JLabel lbl = new JLabel(arrLeftLabels[i]);
+            lbl.setFont(FontUtil.getOutfitBoldFont(13f));
+            lbl.setForeground(new Color(42, 2, 67));
+            lbl.setBounds(95, intYLeft, 200, 40);
+            pnlDetailsContainer.add(lbl);
     
-            JTextField field;
-            if (leftLabels[i].equals("PASSWORD")) {
-                field = new RoundedPasswordField("Enter your password", 20);
-                passwordField = field;
+            JTextField txtField;
+            if (arrLeftLabels[i].equals("PASSWORD")) {
+                txtField = new RoundedPasswordField("Enter your password", 20);
+                txtPasswordField = txtField;
             } else {
-                field = new RoundedTextField("Enter your " + leftLabels[i].toLowerCase(), 20);
+                txtField = new RoundedTextField("Enter your " + arrLeftLabels[i].toLowerCase(), 20);
             }
     
-            field.setFont(FontUtil.getOutfitFont(15f));
-            field.setBackground(Color.WHITE);
-            field.setForeground(Color.BLACK);
-            field.setCaretColor(Color.BLACK);
-            field.setBorder(BorderFactory.createEmptyBorder(5, 10, 5, 10));
-            field.setEditable(false);
-            field.setFocusable(false);
-            textFields.add(field);
+            txtField.setFont(FontUtil.getOutfitFont(15f));
+            txtField.setBackground(Color.WHITE);
+            txtField.setForeground(Color.BLACK);
+            txtField.setCaretColor(Color.BLACK);
+            txtField.setBorder(BorderFactory.createEmptyBorder(5, 10, 5, 10));
+            txtField.setEditable(false);
+            txtField.setFocusable(false);
+            lstTextFields.add(txtField);
     
-            JPanel wrapper = createTextFieldWrapper(field, 20);
-            wrapper.setBounds(95, yLeft + 33, 330, 47);
-            detailsContainer.add(wrapper);
+            JPanel pnlWrapper = createTextFieldWrapper(txtField, 20);
+            pnlWrapper.setBounds(95, intYLeft + 33, 330, 47);
+            pnlDetailsContainer.add(pnlWrapper);
     
             // 🔍 Add real-time validation
-            if (leftLabels[i].equals("PASSWORD")) {
-                ValidationUtil.addTextValidation(field, wrapper, s -> s.length() >= 8);
-            } else if (leftLabels[i].equals("EMAIL ADDRESS")) {
-                ValidationUtil.addTextValidation(field, wrapper, s -> s.matches("^[\\w-.]+@([\\w-]+\\.)+[\\w-]{2,}$"));
-            } else if (leftLabels[i].equals("MOBILE NO. / TEL. NO.")) {
-                ValidationUtil.addTextValidation(field, wrapper, s -> s.matches("^\\+63\\s9\\d{2}-\\d{3}-\\d{4}$"));
-                SmartFieldFormatter.attachMobileFormatter(field);
+            if (arrLeftLabels[i].equals("PASSWORD")) {
+                ValidationUtil.addTextValidation(txtField, pnlWrapper, s -> s.length() >= 8);
+            } else if (arrLeftLabels[i].equals("EMAIL ADDRESS")) {
+                ValidationUtil.addTextValidation(txtField, pnlWrapper, s -> s.matches("^[\\w-.]+@([\\w-]+\\.)+[\\w-]{2,}$"));
+            } else if (arrLeftLabels[i].equals("MOBILE NO. / TEL. NO.")) {
+                ValidationUtil.addTextValidation(txtField, pnlWrapper, s -> s.matches("^\\+63\\s9\\d{2}-\\d{3}-\\d{4}$"));
+                SmartFieldFormatter.attachMobileFormatter(txtField);
             }
     
-            yLeft += 74;
-            if (i == 1) yLeft += 130;
+            intYLeft += 74;
+            if (i == 1) intYLeft += 130;
         }
     
         JLabel contactLabel = new JLabel("Contact Information");
         contactLabel.setFont(FontUtil.getOutfitBoldFont(17f));
         contactLabel.setBounds(95, 350, 300, 20);
-        detailsContainer.add(contactLabel);
+        pnlDetailsContainer.add(contactLabel);
     
         JLabel contactInfo = new JLabel("<html>Keep your contact info up to date so we can reach you with important updates.</html>");
         contactInfo.setFont(FontUtil.getInterFont(14f));
         contactInfo.setBounds(95, 375, 350, 40);
-        detailsContainer.add(contactInfo);
+        pnlDetailsContainer.add(contactInfo);
     
-        int yRight = 150;
-        for (int i = 0; i < rightLabels.length; i++) {
-            String labelText = rightLabels[i];
+        int intYRight = 150;
+        for (int i = 0; i < arrRightLabels.length; i++) {
+            String labelText = arrRightLabels[i];
             JLabel label = new JLabel(labelText);
             label.setFont(FontUtil.getOutfitBoldFont(13f));
             label.setForeground(new Color(42, 2, 67));
     
             if (labelText.equals("BIRTHDAY")) {
-                label.setBounds(490, yRight + 5, 150, 28);
-                detailsContainer.add(label);
+                label.setBounds(490, intYRight + 5, 150, 28);
+                pnlDetailsContainer.add(label);
     
                 JTextField bdayField = new RoundedTextField("MM/DD/YYYY", 15);
                 bdayField.setFont(FontUtil.getOutfitFont(15f));
@@ -147,11 +147,11 @@ public class AccountDetailsPage extends Template {
                 bdayField.setBorder(BorderFactory.createEmptyBorder(5, 10, 5, 10));
                 bdayField.setEditable(false);
                 bdayField.setFocusable(false);
-                textFields.add(bdayField);
+                lstTextFields.add(bdayField);
     
                 JPanel bdayWrapper = createTextFieldWrapper(bdayField, 15);
-                bdayWrapper.setBounds(490, yRight + 31, 210, 47);
-                detailsContainer.add(bdayWrapper);
+                bdayWrapper.setBounds(490, intYRight + 31, 210, 47);
+                pnlDetailsContainer.add(bdayWrapper);
     
                 SmartFieldFormatter.attachDateFormatter(bdayField);
                 ValidationUtil.addTextValidation(bdayField, bdayWrapper, s -> {
@@ -169,32 +169,32 @@ public class AccountDetailsPage extends Template {
                 JLabel genderLabel = new JLabel("GENDER");
                 genderLabel.setFont(FontUtil.getOutfitBoldFont(13f));
                 genderLabel.setForeground(new Color(42, 2, 67));
-                genderLabel.setBounds(730, yRight + 5, 150, 28);
-                detailsContainer.add(genderLabel);
+                genderLabel.setBounds(730, intYRight + 5, 150, 28);
+                pnlDetailsContainer.add(genderLabel);
     
                 JComboBox<String> genderCombo = FormComponent.createStyledComboBox("Choose Gender", new String[]{"Male", "Female"});
                 genderCombo.setEnabled(false);
-                comboBoxes.add(genderCombo);
-                genderCombo.setBounds(730, yRight + 30, 190, 45);
-                detailsContainer.add(genderCombo);
+                lstComboBoxes.add(genderCombo);
+                genderCombo.setBounds(730, intYRight + 30, 190, 45);
+                pnlDetailsContainer.add(genderCombo);
     
-                yRight += 77;
+                intYRight += 77;
                 i++;
             } else if (labelText.equals("CIVIL STATUS")) {
-                label.setBounds(490, yRight + 5, 150, 20);
-                detailsContainer.add(label);
+                label.setBounds(490, intYRight + 5, 150, 20);
+                pnlDetailsContainer.add(label);
     
                 JComboBox<String> civilCombo = FormComponent.createStyledComboBox("Choose Civil Status", new String[]{"Single", "Married", "Separated", "Widow"});
                 civilCombo.setEnabled(false);
-                comboBoxes.add(civilCombo);
-                civilCombo.setBounds(490, yRight + 25, 210, 45);
-                detailsContainer.add(civilCombo);
+                lstComboBoxes.add(civilCombo);
+                civilCombo.setBounds(490, intYRight + 25, 210, 45);
+                pnlDetailsContainer.add(civilCombo);
     
                 JLabel natLabel = new JLabel("NATIONALITY");
                 natLabel.setFont(FontUtil.getOutfitBoldFont(13f));
                 natLabel.setForeground(new Color(42, 2, 67));
-                natLabel.setBounds(730, yRight + 5, 150, 20);
-                detailsContainer.add(natLabel);
+                natLabel.setBounds(730, intYRight + 5, 150, 20);
+                pnlDetailsContainer.add(natLabel);
     
                 JTextField natField = new RoundedTextField("e.g., Filipino", 25);
                 natField.setFont(FontUtil.getOutfitFont(15f));
@@ -204,51 +204,51 @@ public class AccountDetailsPage extends Template {
                 natField.setBorder(BorderFactory.createEmptyBorder(5, 10, 5, 10));
                 natField.setEditable(false);
                 natField.setFocusable(false);
-                textFields.add(natField);
+                lstTextFields.add(natField);
     
                 JPanel natWrapper = createTextFieldWrapper(natField, 15);
-                natWrapper.setBounds(730, yRight + 25, 190, 47);
-                detailsContainer.add(natWrapper);
+                natWrapper.setBounds(730, intYRight + 25, 190, 47);
+                pnlDetailsContainer.add(natWrapper);
     
                 // Optional validation
                 ValidationUtil.addTextValidation(natField, natWrapper, s -> !s.trim().isEmpty());
     
-                yRight += 74;
+                intYRight += 74;
                 i++;
             } else {
-                label.setBounds(490, yRight + 10, 270, 20);
-                detailsContainer.add(label);
+                label.setBounds(490, intYRight + 10, 270, 20);
+                pnlDetailsContainer.add(label);
     
-                JTextField field = new RoundedTextField("Enter " + labelText.toLowerCase(), 20);
-                field.setFont(FontUtil.getOutfitFont(15f));
-                field.setBackground(Color.WHITE);
-                field.setForeground(Color.BLACK);
-                field.setCaretColor(Color.BLACK);
-                field.setBorder(BorderFactory.createEmptyBorder(5, 10, 5, 10));
-                field.setEditable(false);
-                field.setFocusable(false);
-                textFields.add(field);
-    
-                JPanel wrapper = createTextFieldWrapper(field, 15);
-                wrapper.setBounds(490, yRight + 33, 430, 47);
-                detailsContainer.add(wrapper);
-    
+                JTextField txtField = new RoundedTextField("Enter " + labelText.toLowerCase(), 20);
+                txtField.setFont(FontUtil.getOutfitFont(15f));
+                txtField.setBackground(Color.WHITE);
+                txtField.setForeground(Color.BLACK);
+                txtField.setCaretColor(Color.BLACK);
+                txtField.setBorder(BorderFactory.createEmptyBorder(5, 10, 5, 10));
+                txtField.setEditable(false);
+                txtField.setFocusable(false);
+                lstTextFields.add(txtField);
+
+                JPanel pnlWrapper = createTextFieldWrapper(txtField, 15);
+                pnlWrapper.setBounds(490, intYRight + 33, 430, 47);
+                pnlDetailsContainer.add(pnlWrapper);
+
                 // Optional basic validation
-                ValidationUtil.addTextValidation(field, wrapper, s -> !s.trim().isEmpty());
+                ValidationUtil.addTextValidation(txtField, pnlWrapper, s -> !s.trim().isEmpty());
     
-                yRight += 75;
+                intYRight += 75;
             }
         }
     
-        actionButton = new RoundedComponents.RoundedButton("UPDATE", 20);
-        actionButton.setFont(FontUtil.getOutfitBoldFont(18f));
-        actionButton.setBounds(740, 590, 150, 45);
-        styleButton(actionButton);
+        cmdAction = new RoundedComponents.RoundedButton("UPDATE", 20);
+        cmdAction.setFont(FontUtil.getOutfitBoldFont(18f));
+        cmdAction.setBounds(740, 590, 150, 45);
+        styleButton(cmdAction);
     
-        actionButton.addActionListener(e -> {
-            if (!isEditMode) {
-                isEditMode = true;
-                actionButton.setText("SAVE CHANGES");
+        cmdAction.addActionListener(e -> {
+            if (!boolEditMode) {
+                boolEditMode = true;
+                cmdAction.setText("SAVE CHANGES");
                 enableEditing(true);
             } else {
                 if (!validateFields()) {
@@ -258,24 +258,24 @@ public class AccountDetailsPage extends Template {
                 
                 saveChanges();
 
-                isEditMode = false;
-                actionButton.setText("UPDATE");
+                boolEditMode = false;
+                cmdAction.setText("UPDATE");
                 enableEditing(false);
-            }            
+            }
         });
-    
-        detailsContainer.add(actionButton);
-        return detailsContainer;
+
+        pnlDetailsContainer.add(cmdAction);
+        return pnlDetailsContainer;
 
     }
 
     private void enableEditing(boolean enabled) {
-        for (JTextField field : textFields) {
+        for (JTextField field : lstTextFields) {
             field.setEditable(enabled);
             field.setFocusable(enabled); 
             field.setBackground(Color.WHITE);
         }
-        for (JComboBox<String> combo : comboBoxes) {
+        for (JComboBox<String> combo : lstComboBoxes) {
             combo.setEnabled(enabled);
         }
     }
@@ -283,7 +283,7 @@ public class AccountDetailsPage extends Template {
     private boolean validateFields() {
         boolean allValid = true;
     
-        for (JTextField field : textFields) {
+        for (JTextField field : lstTextFields) {
             if (!field.isEditable()) continue;
     
             String newValue = field.getText().trim();
@@ -298,7 +298,7 @@ public class AccountDetailsPage extends Template {
             }
         }
     
-        for (JComboBox<String> combo : comboBoxes) {
+        for (JComboBox<String> combo : lstComboBoxes) {
             if (!combo.isEnabled()) continue; 
     
             if (combo instanceof RoundedComponents.RoundedComboBox<String> styledCombo) {
@@ -315,22 +315,22 @@ public class AccountDetailsPage extends Template {
         try {
             // 1️⃣ Gather all the new values from your UI:
             String origUsername   = UserApplicationData.get("Username");
-            String newPassword    = passwordField.getText().trim();
-            String newEmail       = textFields.get(2).getText().trim();
-            String newMobile      = textFields.get(3).getText().trim();
+            String newPassword    = txtPasswordField.getText().trim();
+            String newEmail       = lstTextFields.get(2).getText().trim();
+            String newMobile      = lstTextFields.get(3).getText().trim();
     
-            String newFullName    = textFields.get(4).getText().trim();
+            String newFullName    = lstTextFields.get(4).getText().trim();
             // parse into a java.util.Date
             java.util.Date utilBirth = new SimpleDateFormat("MM/dd/yyyy")
-                                           .parse(textFields.get(5).getText().trim());
+                                           .parse(lstTextFields.get(5).getText().trim());
             // convert into java.sql.Date for JDBC
             java.sql.Date sqlBirth = new java.sql.Date(utilBirth.getTime());
     
-            String newGender      = (String) comboBoxes.get(0).getSelectedItem();
-            String newCivilStatus = (String) comboBoxes.get(1).getSelectedItem();
-            String newNationality = textFields.get(6).getText().trim();
-            String newSpouse      = textFields.get(7).getText().trim();
-            String newMotherMn    = textFields.get(8).getText().trim();
+            String newGender      = (String) lstComboBoxes.get(0).getSelectedItem();
+            String newCivilStatus = (String) lstComboBoxes.get(1).getSelectedItem();
+            String newNationality = lstTextFields.get(6).getText().trim();
+            String newSpouse      = lstTextFields.get(7).getText().trim();
+            String newMotherMn    = lstTextFields.get(8).getText().trim();
     
             // 2️⃣ Update the DB (note sqlBirth)
             AccountService.updateCustomerInfoByUsername(
@@ -403,20 +403,20 @@ public class AccountDetailsPage extends Template {
       
     private void populateFromSession() {
         // LEFT SIDE:
-        textFields.get(0).setText(UserApplicationData.get("Username"));
-        passwordField        .setText(UserApplicationData.get("Password"));
-        textFields.get(2).setText(UserApplicationData.get("Email"));
-        textFields.get(3).setText(UserApplicationData.get("Mobile"));
+        lstTextFields.get(0).setText(UserApplicationData.get("Username"));
+        txtPasswordField        .setText(UserApplicationData.get("Password"));
+        lstTextFields.get(2).setText(UserApplicationData.get("Email"));
+        lstTextFields.get(3).setText(UserApplicationData.get("Mobile"));
 
         // RIGHT SIDE:
-        textFields.get(4).setText(UserApplicationData.get("CustomerName"));
-        textFields.get(5).setText(UserApplicationData.get("Birthday"));
-        comboBoxes.get(0).setSelectedItem(UserApplicationData.get("Gender"));
-        comboBoxes.get(1).setSelectedItem(UserApplicationData.get("CivilStatus"));
-        textFields.get(6).setText(UserApplicationData.get("Nationality"));
+        lstTextFields.get(4).setText(UserApplicationData.get("CustomerName"));
+        lstTextFields.get(5).setText(UserApplicationData.get("Birthday"));
+        lstComboBoxes.get(0).setSelectedItem(UserApplicationData.get("Gender"));
+        lstComboBoxes.get(1).setSelectedItem(UserApplicationData.get("CivilStatus"));
+        lstTextFields.get(6).setText(UserApplicationData.get("Nationality"));
         String spouse = UserApplicationData.get("Spouse").trim();
-        textFields.get(7).setText(spouse.isEmpty() ? "N/A" : spouse);
-        textFields.get(8).setText(UserApplicationData.get("MaidenName"));
+        lstTextFields.get(7).setText(spouse.isEmpty() ? "N/A" : spouse);
+        lstTextFields.get(8).setText(UserApplicationData.get("MaidenName"));
     }
 
     

--- a/application-system/src/main/java/com/group_9/project/AccountSubsPage.java
+++ b/application-system/src/main/java/com/group_9/project/AccountSubsPage.java
@@ -14,45 +14,45 @@ public class AccountSubsPage extends Template {
     public AccountSubsPage() {
         BaseFrameSetup.applyAppIcon(this);
         setDefaultCloseOperation(JFrame.DISPOSE_ON_CLOSE);
-        BackgroundPanel background = BaseFrameSetup.setupCompleteFrame(this, 3);
+        BackgroundPanel pnlBackground = BaseFrameSetup.setupCompleteFrame(this, 3);
 
-        JPanel sidebar = AccountSidebarUtil.createSidebar(this, "My Subscriptions");
-        background.add(sidebar);
+        JPanel pnlSidebar = AccountSidebarUtil.createSidebar(this, "My Subscriptions");
+        pnlBackground.add(pnlSidebar);
 
-        JPanel content = new RoundedComponents.RoundedShadowPanel(25, 4);
-        content.setBounds(290, 150, 1020, 720);
-        background.add(content);
+        JPanel pnlContent = new RoundedComponents.RoundedShadowPanel(25, 4);
+        pnlContent.setBounds(290, 150, 1020, 720);
+        pnlBackground.add(pnlContent);
 
-        JPanel detailsContainer = createDetailsContainer();
-        content.add(detailsContainer);
+        JPanel pnlDetailsContainer = createDetailsContainer();
+        pnlContent.add(pnlDetailsContainer);
 
-        SwingUtilities.invokeLater(() -> background.requestFocusInWindow());
+        SwingUtilities.invokeLater(() -> pnlBackground.requestFocusInWindow());
     }
 
     
 
 
     private JPanel createDetailsContainer() {
-        JPanel container = new JPanel(null);
-        container.setOpaque(false);
-        container.setBounds(0, 0, 1250, 700);
+        JPanel pnlContainer = new JPanel(null);
+        pnlContainer.setOpaque(false);
+        pnlContainer.setBounds(0, 0, 1250, 700);
     
         // ─── Headers ─────────────────────────────────────────
-        JLabel titleLabel = new JLabel("MY SUBSCRIPTIONS");
-        titleLabel.setFont(FontUtil.getOutfitBoldFont(26f));
-        titleLabel.setForeground(new Color(42,2,67));
-        titleLabel.setBounds(70, 50, 300, 30);
-        container.add(titleLabel);
+        JLabel lblTitle = new JLabel("MY SUBSCRIPTIONS");
+        lblTitle.setFont(FontUtil.getOutfitBoldFont(26f));
+        lblTitle.setForeground(new Color(42,2,67));
+        lblTitle.setBounds(70, 50, 300, 30);
+        pnlContainer.add(lblTitle);
     
-        JLabel sectionLabel = new JLabel("SERVICE AND PLAN SUBSCRIPTIONS");
-        sectionLabel.setFont(FontUtil.getOutfitFont(16f));
-        sectionLabel.setBounds(70, 100, 400, 20);
-        container.add(sectionLabel);
+        JLabel lblSection = new JLabel("SERVICE AND PLAN SUBSCRIPTIONS");
+        lblSection.setFont(FontUtil.getOutfitFont(16f));
+        lblSection.setBounds(70, 100, 400, 20);
+        pnlContainer.add(lblSection);
     
-        JSeparator sep = new JSeparator();
-        sep.setBounds(70, 130, 880, 1);
-        sep.setForeground(new Color(180,180,180));
-        container.add(sep);
+        JSeparator sepDivider = new JSeparator();
+        sepDivider.setBounds(70, 130, 880, 1);
+        sepDivider.setForeground(new Color(180,180,180));
+        pnlContainer.add(sepDivider);
     
         // ─── Fetch subscriptions ────────────────────────────
         String username = UserApplicationData.get("Username");
@@ -65,12 +65,12 @@ public class AccountSubsPage extends Template {
         }
     
         if (subs.isEmpty()) {
-            JLabel none = new JLabel("You have no active subscriptions.");
-            none.setFont(FontUtil.getOutfitFont(18f));
-            none.setForeground(new Color(80,80,80));
-            none.setBounds(100, 200, 400, 30);
-            container.add(none);
-            return container;
+            JLabel lblNone = new JLabel("You have no active subscriptions.");
+            lblNone.setFont(FontUtil.getOutfitFont(18f));
+            lblNone.setForeground(new Color(80,80,80));
+            lblNone.setBounds(100, 200, 400, 30);
+            pnlContainer.add(lblNone);
+            return pnlContainer;
         }
     
         final int boxW = 380, boxH = 220;
@@ -94,17 +94,17 @@ public class AccountSubsPage extends Template {
                     s.dateSubmitted,
                     s.planDetails.planId
                 );
-                container.add(card);
+                pnlContainer.add(card);
             }
         } else {
             // ─── 5 or more: scrollable 2-column grid ───────────
             // 1) Build a JPanel with GridLayout(0,2)
-            JPanel grid = new JPanel(new GridLayout(0, 2, hGap, vGap));
-            grid.setOpaque(false);
+            JPanel pnlGrid = new JPanel(new GridLayout(0, 2, hGap, vGap));
+            pnlGrid.setOpaque(false);
             int rows = (int) Math.ceil(subs.size() / 2.0);
             int gridW = 2 * boxW + hGap;
             int gridH = rows * boxH + (rows - 1) * vGap;
-            grid.setPreferredSize(new Dimension(gridW, gridH));
+            pnlGrid.setPreferredSize(new Dimension(gridW, gridH));
     
             for (Subscription s : subs) {
                 // each card will auto–size via GridLayout
@@ -117,37 +117,37 @@ public class AccountSubsPage extends Template {
                     s.dateSubmitted,
                     s.planDetails.planId
                 );
-                grid.add(card);
+                pnlGrid.add(card);
             }
     
             // 2) Wrap it in a JScrollPane sized to show exactly 4 cards (2×2)
             int viewportWidth  = 2 * boxW + hGap;
             int viewportHeight = 2 * boxH + vGap;
-            JScrollPane scroll = new JScrollPane(
-                    grid,
+            JScrollPane scrScroll = new JScrollPane(
+                    pnlGrid,
                     JScrollPane.VERTICAL_SCROLLBAR_AS_NEEDED,
                     JScrollPane.HORIZONTAL_SCROLLBAR_NEVER);
-            scroll.setBounds(startX, startY, viewportWidth, viewportHeight);
-            scroll.setBorder(null);
-            scroll.setOpaque(false);
-            scroll.getViewport().setOpaque(false);
+            scrScroll.setBounds(startX, startY, viewportWidth, viewportHeight);
+            scrScroll.setBorder(null);
+            scrScroll.setOpaque(false);
+            scrScroll.getViewport().setOpaque(false);
 
-            JScrollBar vsb = scroll.getVerticalScrollBar();
-            vsb.setUI(new CustomScrollBarUI());
-            vsb.setOpaque(false);
-            vsb.setPreferredSize(new Dimension(10, 0));
-            vsb.setUnitIncrement(16);
+            JScrollBar sbVertical = scrScroll.getVerticalScrollBar();
+            sbVertical.setUI(new CustomScrollBarUI());
+            sbVertical.setOpaque(false);
+            sbVertical.setPreferredSize(new Dimension(10, 0));
+            sbVertical.setUnitIncrement(16);
     
-            container.add(scroll);
+            pnlContainer.add(scrScroll);
         }
     
-        return container;
+        return pnlContainer;
     }
     
 
     JPanel createWhiteBox(int x, int y, String product, String monthlyFee, String installFee,
                                   String appNo, String submittedDate, String planId) {
-        JPanel applicantBox = new JPanel(null) {
+        JPanel pnlApplicantBox = new JPanel(null) {
             protected void paintComponent(Graphics g) {
                 Graphics2D g2 = (Graphics2D) g.create();
                 g2.setRenderingHint(RenderingHints.KEY_ANTIALIASING, RenderingHints.VALUE_ANTIALIAS_ON);
@@ -163,54 +163,54 @@ public class AccountSubsPage extends Template {
                 return false;
             }
         };
-        applicantBox.setBounds(x, y, 380, 220);
-        applicantBox.setPreferredSize(new Dimension(380, 220));
+        pnlApplicantBox.setBounds(x, y, 380, 220);
+        pnlApplicantBox.setPreferredSize(new Dimension(380, 220));
 
-        JLabel header = new JLabel("Product and Service");
-        header.setFont(FontUtil.getOutfitFont(17f));
-        header.setBounds(20, 15, 200, 20);
-        applicantBox.add(header);
+        JLabel lblHeader = new JLabel("Product and Service");
+        lblHeader.setFont(FontUtil.getOutfitFont(17f));
+        lblHeader.setBounds(20, 15, 200, 20);
+        pnlApplicantBox.add(lblHeader);
 
-        JLabel amount = new JLabel("Amount");
-        amount.setFont(FontUtil.getOutfitFont(17f));
-        amount.setBounds(275, 15, 80, 20);
-        applicantBox.add(amount);
+        JLabel lblAmount = new JLabel("Amount");
+        lblAmount.setFont(FontUtil.getOutfitFont(17f));
+        lblAmount.setBounds(275, 15, 80, 20);
+        pnlApplicantBox.add(lblAmount);
 
-        JSeparator sep = new JSeparator();
-        sep.setBounds(20, 50, 340, 1);
-        sep.setForeground(Color.BLACK);
-        applicantBox.add(sep);
+        JSeparator sepSeparator = new JSeparator();
+        sepSeparator.setBounds(20, 50, 340, 1);
+        sepSeparator.setForeground(Color.BLACK);
+        pnlApplicantBox.add(sepSeparator);
 
-        JLabel plan = new JLabel("<html><b>" + product + "</b><br>Monthly Service Fee<br>Installation Fee</html>");
-        plan.setFont(FontUtil.getOutfitFont(18f));
-        plan.setBounds(20, 65, 200, 60);
-        applicantBox.add(plan);
+        JLabel lblPlan = new JLabel("<html><b>" + product + "</b><br>Monthly Service Fee<br>Installation Fee</html>");
+        lblPlan.setFont(FontUtil.getOutfitFont(18f));
+        lblPlan.setBounds(20, 65, 200, 60);
+        pnlApplicantBox.add(lblPlan);
 
-        JLabel price = new JLabel("<html><br>" + monthlyFee + "<br>" + installFee + "</html>");
-        price.setFont(FontUtil.getOutfitFont(18f));
-        price.setBounds(260, 65, 100, 60);
-        applicantBox.add(price);
+        JLabel lblPrice = new JLabel("<html><br>" + monthlyFee + "<br>" + installFee + "</html>");
+        lblPrice.setFont(FontUtil.getOutfitFont(18f));
+        lblPrice.setBounds(260, 65, 100, 60);
+        pnlApplicantBox.add(lblPrice);
 
-        JLabel details = new JLabel("<html><br><br>APPLICATION NO. " + appNo +
+        JLabel lblDetails = new JLabel("<html><br><br>APPLICATION NO. " + appNo +
                 "<br>DATE SUBMITTED: " + submittedDate + "</html>");
-        details.setFont(FontUtil.getOutfitBoldFont(12f));
-        details.setBounds(20, 130, 300, 75);
-        applicantBox.add(details);
+        lblDetails.setFont(FontUtil.getOutfitBoldFont(12f));
+        lblDetails.setBounds(20, 130, 300, 75);
+        pnlApplicantBox.add(lblDetails);
 
-        RoundedComponents.RoundedButton unsubBtn = new RoundedComponents.RoundedButton("UNSUBSCRIBE", 20);
-        unsubBtn.setFont(FontUtil.getOutfitBoldFont(14f));
-        unsubBtn.setBounds(230, 170, 130, 35);
-        unsubBtn.setBackground(new Color(98, 60, 187));
-        unsubBtn.setForeground(Color.WHITE);
-        unsubBtn.setBorderColor(new Color(98, 60, 187));
-        unsubBtn.setCursor(Cursor.getPredefinedCursor(Cursor.HAND_CURSOR));
+        RoundedComponents.RoundedButton cmdUnsub = new RoundedComponents.RoundedButton("UNSUBSCRIBE", 20);
+        cmdUnsub.setFont(FontUtil.getOutfitBoldFont(14f));
+        cmdUnsub.setBounds(230, 170, 130, 35);
+        cmdUnsub.setBackground(new Color(98, 60, 187));
+        cmdUnsub.setForeground(Color.WHITE);
+        cmdUnsub.setBorderColor(new Color(98, 60, 187));
+        cmdUnsub.setCursor(Cursor.getPredefinedCursor(Cursor.HAND_CURSOR));
         ButtonHoverEffect.apply(
-                unsubBtn,
+                cmdUnsub,
                 new Color(75, 39, 143), Color.WHITE,
                 new Color(98, 60, 187), Color.WHITE,
                 new Color(120, 90, 200), new Color(98, 60, 187)
         );
-        unsubBtn.addActionListener(e -> {
+        cmdUnsub.addActionListener(e -> {
             boolean confirm = CustomDialogUtil.showStyledConfirmDialog(
                     AccountSubsPage.this,
                     "Unsubscribe",
@@ -243,9 +243,9 @@ public class AccountSubsPage extends Template {
                 );
             }
         });
-        applicantBox.add(unsubBtn);
+        pnlApplicantBox.add(cmdUnsub);
 
-        return applicantBox;
+        return pnlApplicantBox;
     }
 
     

--- a/application-system/src/main/java/com/group_9/project/AddConfirm.java
+++ b/application-system/src/main/java/com/group_9/project/AddConfirm.java
@@ -21,114 +21,114 @@ import java.util.function.Predicate;
 
 public class AddConfirm extends JFrame {
 
-    private RoundedComponents.RoundedTextField cardholderName, cardNumber, expiryDate, cvv;
-    private final List<JTextComponent> paymentFields = new ArrayList<>();
-    private JRadioButton full, install;
+    private RoundedComponents.RoundedTextField txtCardholderName, txtCardNumber, txtExpiryDate, txtCvv;
+    private final List<JTextComponent> lstPaymentFields = new ArrayList<>();
+    private JRadioButton rbtnFull, rbtnInstall;
 
     public AddConfirm() {
         BaseFrameSetup.applyAppIcon(this);
-        BackgroundPanel background = BaseFrameSetup.setupCompleteFrame(this, 1);
+        BackgroundPanel pnlBackground = BaseFrameSetup.setupCompleteFrame(this, 1);
 
         // — White rounded container
-        JPanel container = new RoundedComponents.RoundedShadowPanel(25, 4);
-        container.setBounds(235, 165, 970, 695);
-        background.add(container);
+        JPanel pnlContainer = new RoundedComponents.RoundedShadowPanel(25, 4);
+        pnlContainer.setBounds(235, 165, 970, 695);
+        pnlBackground.add(pnlContainer);
 
         // — Inner content
-        JPanel inner = new JPanel();
-        inner.setLayout(new BoxLayout(inner, BoxLayout.Y_AXIS));
-        inner.setOpaque(false);
-        inner.setBounds(40, 40, 890, 615);
-        container.add(inner);
+        JPanel pnlInnerContent = new JPanel();
+        pnlInnerContent.setLayout(new BoxLayout(pnlInnerContent, BoxLayout.Y_AXIS));
+        pnlInnerContent.setOpaque(false);
+        pnlInnerContent.setBounds(40, 40, 890, 615);
+        pnlContainer.add(pnlInnerContent);
 
-        inner.add(Box.createRigidArea(new Dimension(0, 20)));
-        JLabel title = new JLabel("SERVICE APPLICATION", SwingConstants.CENTER);
-        title.setFont(FontUtil.getOutfitBoldFont(26f));
-        title.setForeground(Color.decode("#2B0243"));
-        title.setAlignmentX(Component.CENTER_ALIGNMENT);
-        inner.add(title);
+        pnlInnerContent.add(Box.createRigidArea(new Dimension(0, 20)));
+        JLabel lblTitle = new JLabel("SERVICE APPLICATION", SwingConstants.CENTER);
+        lblTitle.setFont(FontUtil.getOutfitBoldFont(26f));
+        lblTitle.setForeground(Color.decode("#2B0243"));
+        lblTitle.setAlignmentX(Component.CENTER_ALIGNMENT);
+        pnlInnerContent.add(lblTitle);
 
-        inner.add(Box.createRigidArea(new Dimension(0, 20)));
-        JPanel steps = new JPanel(new FlowLayout(FlowLayout.CENTER));
-        steps.setOpaque(false);
-        steps.add(CreateStepTracker.createStepTracker(2));
-        inner.add(steps);
+        pnlInnerContent.add(Box.createRigidArea(new Dimension(0, 20)));
+        JPanel pnlStepWrapper = new JPanel(new FlowLayout(FlowLayout.CENTER));
+        pnlStepWrapper.setOpaque(false);
+        pnlStepWrapper.add(CreateStepTracker.createStepTracker(2));
+        pnlInnerContent.add(pnlStepWrapper);
 
-        inner.add(Box.createRigidArea(new Dimension(0, 20)));
+        pnlInnerContent.add(Box.createRigidArea(new Dimension(0, 20)));
 
         // Subtitle + Note
         Color subColor = Color.decode("#302E2E");
-        JLabel subtitle = new JLabel("SECURE YOUR PAYMENT", SwingConstants.LEFT);
-        subtitle.setFont(FontUtil.getOutfitFont(16f));
-        subtitle.setForeground(subColor);
-        JLabel subNote = new JLabel("Complete your application by confirming payment for the selected plans.");
-        subNote.setFont(FontUtil.getInterFont(14f));
-        subNote.setForeground(subColor);
+        JLabel lblSubtitle = new JLabel("SECURE YOUR PAYMENT", SwingConstants.LEFT);
+        lblSubtitle.setFont(FontUtil.getOutfitFont(16f));
+        lblSubtitle.setForeground(subColor);
+        JLabel lblSubNote = new JLabel("Complete your application by confirming payment for the selected plans.");
+        lblSubNote.setFont(FontUtil.getInterFont(14f));
+        lblSubNote.setForeground(subColor);
 
-        JPanel infoPanel = new JPanel(new BorderLayout());
-        infoPanel.setOpaque(false);
-        infoPanel.setMaximumSize(new Dimension(826, 60));
-        JPanel leftLabels = new JPanel();
-        leftLabels.setOpaque(false);
-        leftLabels.setLayout(new BoxLayout(leftLabels, BoxLayout.Y_AXIS));
-        leftLabels.add(subtitle);
-        leftLabels.add(Box.createRigidArea(new Dimension(0, 5)));
-        leftLabels.add(subNote);
-        infoPanel.add(leftLabels, BorderLayout.WEST);
-        inner.add(infoPanel);
+        JPanel pnlInfoPanel = new JPanel(new BorderLayout());
+        pnlInfoPanel.setOpaque(false);
+        pnlInfoPanel.setMaximumSize(new Dimension(826, 60));
+        JPanel pnlLeftLabels = new JPanel();
+        pnlLeftLabels.setOpaque(false);
+        pnlLeftLabels.setLayout(new BoxLayout(pnlLeftLabels, BoxLayout.Y_AXIS));
+        pnlLeftLabels.add(lblSubtitle);
+        pnlLeftLabels.add(Box.createRigidArea(new Dimension(0, 5)));
+        pnlLeftLabels.add(lblSubNote);
+        pnlInfoPanel.add(pnlLeftLabels, BorderLayout.WEST);
+        pnlInnerContent.add(pnlInfoPanel);
 
-        inner.add(Box.createRigidArea(new Dimension(0, 10)));
-        JSeparator sep = new JSeparator(SwingConstants.HORIZONTAL);
-        sep.setMaximumSize(new Dimension(826, 2));
-        sep.setForeground(Color.decode("#B2B2B2"));
-        sep.setAlignmentX(Component.CENTER_ALIGNMENT);
-        inner.add(sep);
-        inner.add(Box.createRigidArea(new Dimension(0, 20)));
+        pnlInnerContent.add(Box.createRigidArea(new Dimension(0, 10)));
+        JSeparator sepDivider = new JSeparator(SwingConstants.HORIZONTAL);
+        sepDivider.setMaximumSize(new Dimension(826, 2));
+        sepDivider.setForeground(Color.decode("#B2B2B2"));
+        sepDivider.setAlignmentX(Component.CENTER_ALIGNMENT);
+        pnlInnerContent.add(sepDivider);
+        pnlInnerContent.add(Box.createRigidArea(new Dimension(0, 20)));
 
         // Plan summary + payment section
-        JPanel row = new JPanel();
-        row.setOpaque(false);
-        row.setLayout(new BoxLayout(row, BoxLayout.X_AXIS));
-        row.add(createPlanSummaryPanel());
-        row.add(Box.createRigidArea(new Dimension(30, 0)));
-        row.add(createPaymentSectionPanel());
-        inner.add(row);
+        JPanel pnlRow = new JPanel();
+        pnlRow.setOpaque(false);
+        pnlRow.setLayout(new BoxLayout(pnlRow, BoxLayout.X_AXIS));
+        pnlRow.add(createPlanSummaryPanel());
+        pnlRow.add(Box.createRigidArea(new Dimension(30, 0)));
+        pnlRow.add(createPaymentSectionPanel());
+        pnlInnerContent.add(pnlRow);
 
-        inner.add(Box.createRigidArea(new Dimension(0, 40)));
+        pnlInnerContent.add(Box.createRigidArea(new Dimension(0, 40)));
 
         // Buttons
-        JPanel btnPanel = new JPanel(new BorderLayout());
-        btnPanel.setOpaque(false);
-        btnPanel.setMaximumSize(new Dimension(826, 50));
+        JPanel pnlBtnPanel = new JPanel(new BorderLayout());
+        pnlBtnPanel.setOpaque(false);
+        pnlBtnPanel.setMaximumSize(new Dimension(826, 50));
 
-        RoundedComponents.RoundedButton back = new RoundedComponents.RoundedButton("BACK", 25);
-        styleBackButton(back);
-        back.addActionListener(e -> {
+        RoundedComponents.RoundedButton cmdBack = new RoundedComponents.RoundedButton("BACK", 25);
+        styleBackButton(cmdBack);
+        cmdBack.addActionListener(e -> {
             saveFormState();
             new AddPlansPage().setVisible(true);
             dispose();
         });
 
-        RoundedComponents.RoundedButton confirm = new RoundedComponents.RoundedButton("CONFIRM PAYMENT", 25);
-        styleConfirmButton(confirm);
-        confirm.addMouseListener(new MouseAdapter(){
+        RoundedComponents.RoundedButton cmdConfirm = new RoundedComponents.RoundedButton("CONFIRM PAYMENT", 25);
+        styleConfirmButton(cmdConfirm);
+        cmdConfirm.addMouseListener(new MouseAdapter(){
             public void mouseEntered(MouseEvent e) {
-                confirm.setBackground(Color.decode("#4B278F"));
-                confirm.setBorderColor(Color.decode("#4B278F"));
+                cmdConfirm.setBackground(Color.decode("#4B278F"));
+                cmdConfirm.setBorderColor(Color.decode("#4B278F"));
             }
             public void mouseExited(MouseEvent e) {
-                confirm.setBackground(Color.decode("#623CBB"));
-                confirm.setBorderColor(Color.decode("#623CBB"));
+                cmdConfirm.setBackground(Color.decode("#623CBB"));
+                cmdConfirm.setBorderColor(Color.decode("#623CBB"));
             }
         });
-        confirm.addActionListener(e -> onConfirm());
+        cmdConfirm.addActionListener(e -> onConfirm());
 
-        btnPanel.add(back, BorderLayout.WEST);
-        btnPanel.add(confirm, BorderLayout.EAST);
-        inner.add(btnPanel);
+        pnlBtnPanel.add(cmdBack, BorderLayout.WEST);
+        pnlBtnPanel.add(cmdConfirm, BorderLayout.EAST);
+        pnlInnerContent.add(pnlBtnPanel);
 
         setVisible(true);
-        SwingUtilities.invokeLater(() -> background.requestFocusInWindow());
+        SwingUtilities.invokeLater(() -> pnlBackground.requestFocusInWindow());
 
         // restore any saved inputs
         loadFormState();
@@ -148,7 +148,7 @@ public class AddConfirm extends JFrame {
             return;
         }
 
-        String paymentOpt = full.isSelected() ? "full" : "installment";
+        String paymentOpt = rbtnFull.isSelected() ? "full" : "installment";
         String[] planIds = Optional.ofNullable(UserApplicationData.get("selectedPlanIDs"))
                                    .map(s -> s.split(","))
                                    .orElse(new String[0]);
@@ -231,7 +231,7 @@ public class AddConfirm extends JFrame {
 
     private boolean validateAllFields() {
         boolean ok = true;
-        for (JTextComponent fld : paymentFields) {
+        for (JTextComponent fld : lstPaymentFields) {
             if (fld.getText().trim().isEmpty()) {
                 ok = false;
                 if (fld instanceof RoundedComponents.RoundedTextField tf) tf.setValidationBorderColor(Color.RED);
@@ -246,7 +246,7 @@ public class AddConfirm extends JFrame {
             );
             return false;
         }
-        if (!full.isSelected() && !install.isSelected()) {
+        if (!rbtnFull.isSelected() && !rbtnInstall.isSelected()) {
             CustomDialogUtil.showStyledErrorDialog(this,
                 "Payment Option Required",
                 "Please select a payment option."
@@ -258,25 +258,25 @@ public class AddConfirm extends JFrame {
     }
 
     private void saveFormState() {
-        UserApplicationData.set("cardholderName", cardholderName.getText());
-        UserApplicationData.set("cardNumber",     cardNumber.getText());
-        UserApplicationData.set("expiryDate",     expiryDate.getText());
-        UserApplicationData.set("cvv",            cvv.getText());
-        UserApplicationData.set("paymentOption", full.isSelected()? "full":"installment");
+        UserApplicationData.set("cardholderName", txtCardholderName.getText());
+        UserApplicationData.set("cardNumber",     txtCardNumber.getText());
+        UserApplicationData.set("expiryDate",     txtExpiryDate.getText());
+        UserApplicationData.set("cvv",            txtCvv.getText());
+        UserApplicationData.set("paymentOption", rbtnFull.isSelected()? "full":"installment");
     }
 
     private void loadFormState() {
         Optional.ofNullable(UserApplicationData.get("cardholderName"))
-                .ifPresent(cardholderName::setText);
+                .ifPresent(txtCardholderName::setText);
         Optional.ofNullable(UserApplicationData.get("cardNumber"))
-                .ifPresent(cardNumber::setText);
+                .ifPresent(txtCardNumber::setText);
         Optional.ofNullable(UserApplicationData.get("expiryDate"))
-                .ifPresent(expiryDate::setText);
+                .ifPresent(txtExpiryDate::setText);
         Optional.ofNullable(UserApplicationData.get("cvv"))
-                .ifPresent(cvv::setText);
+                .ifPresent(txtCvv::setText);
         String opt = UserApplicationData.get("paymentOption");
-        if ("full".equals(opt)) full.setSelected(true);
-        else if ("installment".equals(opt)) install.setSelected(true);
+        if ("full".equals(opt)) rbtnFull.setSelected(true);
+        else if ("installment".equals(opt)) rbtnInstall.setSelected(true);
     }
 
     // --- All helper/UI methods below ---
@@ -291,80 +291,80 @@ public class AddConfirm extends JFrame {
         parent.setAlignmentX(Component.LEFT_ALIGNMENT);
         parent.setBorder(BorderFactory.createEmptyBorder(0, 27, 0, 0));
 
-        JLabel summaryTitle = new JLabel("Your Plan Summary");
-        summaryTitle.setFont(FontUtil.getOutfitFont(15f));
-        summaryTitle.setForeground(txtColor);
-        parent.add(summaryTitle);
+        JLabel lblSummaryTitle = new JLabel("Your Plan Summary");
+        lblSummaryTitle.setFont(FontUtil.getOutfitFont(15f));
+        lblSummaryTitle.setForeground(txtColor);
+        parent.add(lblSummaryTitle);
         parent.add(Box.createRigidArea(new Dimension(0, 20)));
 
-        RoundedPanel summaryContent = new RoundedPanel(20);
-        summaryContent.setLayout(new BoxLayout(summaryContent, BoxLayout.Y_AXIS));
-        summaryContent.setBackground(Color.WHITE);
-        summaryContent.setBorder(BorderFactory.createEmptyBorder(20, 20, 20, 20));
+        RoundedPanel pnlSummaryContent = new RoundedPanel(20);
+        pnlSummaryContent.setLayout(new BoxLayout(pnlSummaryContent, BoxLayout.Y_AXIS));
+        pnlSummaryContent.setBackground(Color.WHITE);
+        pnlSummaryContent.setBorder(BorderFactory.createEmptyBorder(20, 20, 20, 20));
 
-        JPanel header = new JPanel(new GridLayout(1, 2));
-        header.setOpaque(false);
-        header.add(new JLabel("Product and Service") {{
+        JPanel pnlHeader = new JPanel(new GridLayout(1, 2));
+        pnlHeader.setOpaque(false);
+        pnlHeader.add(new JLabel("Product and Service") {{
             setFont(FontUtil.getInterFont(16f));
             setForeground(txtColor);
         }});
-        header.add(new JLabel("Amount") {{
+        pnlHeader.add(new JLabel("Amount") {{
             setFont(FontUtil.getInterFont(16f));
             setForeground(txtColor);
             setHorizontalAlignment(SwingConstants.RIGHT);
         }});
-        summaryContent.add(header);
-        summaryContent.add(Box.createRigidArea(new Dimension(0, 10)));
-        summaryContent.add(new JSeparator(SwingConstants.HORIZONTAL) {{
+        pnlSummaryContent.add(pnlHeader);
+        pnlSummaryContent.add(Box.createRigidArea(new Dimension(0, 10)));
+        pnlSummaryContent.add(new JSeparator(SwingConstants.HORIZONTAL) {{
             setMaximumSize(new Dimension(331, 2));
             setForeground(Color.decode("#B2B2B2"));
         }});
-        summaryContent.add(Box.createRigidArea(new Dimension(0, 20)));
+        pnlSummaryContent.add(Box.createRigidArea(new Dimension(0, 20)));
 
         String savedPlans = UserApplicationData.get("selectedPlans");
         if (savedPlans != null && !savedPlans.isEmpty()) {
             String[] plans = savedPlans.split(",");
             for (int i = 0; i < plans.length; i++) {
                 String plan = plans[i].trim();
-                summaryContent.add(new GridPanel(plan, ""));
-                summaryContent.add(new GridPanel("Monthly Service Fee", getPriceForPlan(plan)));
-                summaryContent.add(new GridPanel("Installation Fee", getInstallationFeeForPlan(plan)));
-                if (i < plans.length - 1) summaryContent.add(Box.createRigidArea(new Dimension(0, 20)));
+                pnlSummaryContent.add(new GridPanel(plan, ""));
+                pnlSummaryContent.add(new GridPanel("Monthly Service Fee", getPriceForPlan(plan)));
+                pnlSummaryContent.add(new GridPanel("Installation Fee", getInstallationFeeForPlan(plan)));
+                if (i < plans.length - 1) pnlSummaryContent.add(Box.createRigidArea(new Dimension(0, 20)));
             }
         }
 
-        JScrollPane scrollPane = new JScrollPane(summaryContent);
-        scrollPane.setPreferredSize(new Dimension(375, 210));
-        scrollPane.setHorizontalScrollBarPolicy(JScrollPane.HORIZONTAL_SCROLLBAR_NEVER);
-        scrollPane.setVerticalScrollBarPolicy(JScrollPane.VERTICAL_SCROLLBAR_NEVER);
-        scrollPane.setBorder(null);
-        scrollPane.setOpaque(false);
-        scrollPane.getViewport().setOpaque(false);
+        JScrollPane scrSummary = new JScrollPane(pnlSummaryContent);
+        scrSummary.setPreferredSize(new Dimension(375, 210));
+        scrSummary.setHorizontalScrollBarPolicy(JScrollPane.HORIZONTAL_SCROLLBAR_NEVER);
+        scrSummary.setVerticalScrollBarPolicy(JScrollPane.VERTICAL_SCROLLBAR_NEVER);
+        scrSummary.setBorder(null);
+        scrSummary.setOpaque(false);
+        scrSummary.getViewport().setOpaque(false);
 
-        JScrollBar vsb = scrollPane.getVerticalScrollBar();
-        vsb.setUI(new CustomScrollBarUI());
-        vsb.setPreferredSize(new Dimension(8, Integer.MAX_VALUE));
-        vsb.setUnitIncrement(16);
-        vsb.setVisible(false);
+        JScrollBar sbVertical = scrSummary.getVerticalScrollBar();
+        sbVertical.setUI(new CustomScrollBarUI());
+        sbVertical.setPreferredSize(new Dimension(8, Integer.MAX_VALUE));
+        sbVertical.setUnitIncrement(16);
+        sbVertical.setVisible(false);
 
-        scrollPane.addMouseListener(new java.awt.event.MouseAdapter() {
+        scrSummary.addMouseListener(new java.awt.event.MouseAdapter() {
             @Override
             public void mouseEntered(java.awt.event.MouseEvent e) {
-                vsb.setVisible(true);
-                scrollPane.setVerticalScrollBarPolicy(JScrollPane.VERTICAL_SCROLLBAR_AS_NEEDED);
-                scrollPane.revalidate();
-                scrollPane.repaint();
+                sbVertical.setVisible(true);
+                scrSummary.setVerticalScrollBarPolicy(JScrollPane.VERTICAL_SCROLLBAR_AS_NEEDED);
+                scrSummary.revalidate();
+                scrSummary.repaint();
             }
             @Override
             public void mouseExited(java.awt.event.MouseEvent e) {
-                vsb.setVisible(false);
-                scrollPane.setVerticalScrollBarPolicy(JScrollPane.VERTICAL_SCROLLBAR_NEVER);
-                scrollPane.revalidate();
-                scrollPane.repaint();
+                sbVertical.setVisible(false);
+                scrSummary.setVerticalScrollBarPolicy(JScrollPane.VERTICAL_SCROLLBAR_NEVER);
+                scrSummary.revalidate();
+                scrSummary.repaint();
             }
         });
 
-        RoundedScrollContainer wrapper = new RoundedScrollContainer(scrollPane, 20);
+        RoundedScrollContainer wrapper = new RoundedScrollContainer(scrSummary, 20);
         wrapper.setPreferredSize(new Dimension(375, 210));
         wrapper.setBackground(Color.WHITE);
 
@@ -385,18 +385,18 @@ public class AddConfirm extends JFrame {
     private JPanel createPaymentSectionPanel() {
         Color txtColor = Color.decode("#1E1E1E");
 
-        JPanel paymentPanel = new JPanel();
-        paymentPanel.setLayout(new BoxLayout(paymentPanel, BoxLayout.Y_AXIS));
-        paymentPanel.setOpaque(false);
-        paymentPanel.setBorder(BorderFactory.createEmptyBorder(0, 50, 10, 0));
-        paymentPanel.setMaximumSize(new Dimension(400, 450));
+        JPanel pnlPaymentPanel = new JPanel();
+        pnlPaymentPanel.setLayout(new BoxLayout(pnlPaymentPanel, BoxLayout.Y_AXIS));
+        pnlPaymentPanel.setOpaque(false);
+        pnlPaymentPanel.setBorder(BorderFactory.createEmptyBorder(0, 50, 10, 0));
+        pnlPaymentPanel.setMaximumSize(new Dimension(400, 450));
 
-        JLabel paymentTitle = new JLabel("Payment Section");
-        paymentTitle.setFont(FontUtil.getOutfitFont(15f));
-        paymentTitle.setForeground(txtColor);
-        paymentTitle.setAlignmentX(Component.LEFT_ALIGNMENT);
-        paymentPanel.add(paymentTitle);
-        paymentPanel.add(Box.createRigidArea(new Dimension(0, 20)));
+        JLabel lblPaymentTitle = new JLabel("Payment Section");
+        lblPaymentTitle.setFont(FontUtil.getOutfitFont(15f));
+        lblPaymentTitle.setForeground(txtColor);
+        lblPaymentTitle.setAlignmentX(Component.LEFT_ALIGNMENT);
+        pnlPaymentPanel.add(lblPaymentTitle);
+        pnlPaymentPanel.add(Box.createRigidArea(new Dimension(0, 20)));
 
         ButtonGroup paymentGroup = new ButtonGroup();
         ImageIcon iconOff = new ImageIcon(getClass().getResource("/icons/radio_off.png"));
@@ -405,63 +405,63 @@ public class AddConfirm extends JFrame {
         iconOff = new ImageIcon(iconOff.getImage().getScaledInstance(iconSize, iconSize, Image.SCALE_SMOOTH));
         iconOn  = new ImageIcon(iconOn.getImage().getScaledInstance(iconSize, iconSize, Image.SCALE_SMOOTH));
 
-        full = new JRadioButton("Full Payment");
-        full.setFont(FontUtil.getInterFont(15f));
-        full.setForeground(txtColor);
-        full.setOpaque(false);
-        full.setFocusPainted(false);
-        full.setContentAreaFilled(false);
-        full.setBorderPainted(false);
-        full.setIcon(iconOff);
-        full.setSelectedIcon(iconOn);
+        rbtnFull = new JRadioButton("Full Payment");
+        rbtnFull.setFont(FontUtil.getInterFont(15f));
+        rbtnFull.setForeground(txtColor);
+        rbtnFull.setOpaque(false);
+        rbtnFull.setFocusPainted(false);
+        rbtnFull.setContentAreaFilled(false);
+        rbtnFull.setBorderPainted(false);
+        rbtnFull.setIcon(iconOff);
+        rbtnFull.setSelectedIcon(iconOn);
 
-        install = new JRadioButton("Installment");
-        install.setFont(FontUtil.getInterFont(15f));
-        install.setForeground(txtColor);
-        install.setOpaque(false);
-        install.setFocusPainted(false);
-        install.setContentAreaFilled(false);
-        install.setBorderPainted(false);
-        install.setIcon(iconOff);
-        install.setSelectedIcon(iconOn);
+        rbtnInstall = new JRadioButton("Installment");
+        rbtnInstall.setFont(FontUtil.getInterFont(15f));
+        rbtnInstall.setForeground(txtColor);
+        rbtnInstall.setOpaque(false);
+        rbtnInstall.setFocusPainted(false);
+        rbtnInstall.setContentAreaFilled(false);
+        rbtnInstall.setBorderPainted(false);
+        rbtnInstall.setIcon(iconOff);
+        rbtnInstall.setSelectedIcon(iconOn);
 
-        paymentGroup.add(full);
-        paymentGroup.add(install);
+        paymentGroup.add(rbtnFull);
+        paymentGroup.add(rbtnInstall);
 
-        JPanel radioPanel = new JPanel();
-        radioPanel.setLayout(new BoxLayout(radioPanel, BoxLayout.X_AXIS));
-        radioPanel.setOpaque(false);
-        radioPanel.setAlignmentX(Component.LEFT_ALIGNMENT);
-        radioPanel.add(full);
-        radioPanel.add(Box.createRigidArea(new Dimension(10, 0)));
-        radioPanel.add(install);
+        JPanel pnlRadioPanel = new JPanel();
+        pnlRadioPanel.setLayout(new BoxLayout(pnlRadioPanel, BoxLayout.X_AXIS));
+        pnlRadioPanel.setOpaque(false);
+        pnlRadioPanel.setAlignmentX(Component.LEFT_ALIGNMENT);
+        pnlRadioPanel.add(rbtnFull);
+        pnlRadioPanel.add(Box.createRigidArea(new Dimension(10, 0)));
+        pnlRadioPanel.add(rbtnInstall);
 
-        paymentPanel.add(radioPanel);
-        paymentPanel.add(Box.createRigidArea(new Dimension(0, 25)));
+        pnlPaymentPanel.add(pnlRadioPanel);
+        pnlPaymentPanel.add(Box.createRigidArea(new Dimension(0, 25)));
 
         // Cardholder Name
-        cardholderName = createValidatedField("Cardholder Name", s -> !s.trim().isEmpty());
-        ToolTipUtil.attachCustomTooltip(cardholderName, "Enter name as shown on card");
-        cardholderName.setAlignmentX(Component.LEFT_ALIGNMENT);
-        paymentPanel.add(cardholderName);
-        paymentPanel.add(Box.createRigidArea(new Dimension(0, 10)));
+        txtCardholderName = createValidatedField("Cardholder Name", s -> !s.trim().isEmpty());
+        ToolTipUtil.attachCustomTooltip(txtCardholderName, "Enter name as shown on card");
+        txtCardholderName.setAlignmentX(Component.LEFT_ALIGNMENT);
+        pnlPaymentPanel.add(txtCardholderName);
+        pnlPaymentPanel.add(Box.createRigidArea(new Dimension(0, 10)));
 
         // Card Number
-        cardNumber = createValidatedField("Card Number", s -> s.matches("(\\d{4} ){3}\\d{4}"));
-        SmartFieldFormatter.attachCardNumberFormatter(cardNumber);
-        ((AbstractDocument) cardNumber.getDocument()).setDocumentFilter(new LengthLimitFilter(19));
-        ToolTipUtil.attachCustomTooltip(cardNumber, "Enter 16-digit card number");
-        cardNumber.setAlignmentX(Component.LEFT_ALIGNMENT);
-        paymentPanel.add(cardNumber);
-        paymentPanel.add(Box.createRigidArea(new Dimension(0, 10)));
+        txtCardNumber = createValidatedField("Card Number", s -> s.matches("(\\d{4} ){3}\\d{4}"));
+        SmartFieldFormatter.attachCardNumberFormatter(txtCardNumber);
+        ((AbstractDocument) txtCardNumber.getDocument()).setDocumentFilter(new LengthLimitFilter(19));
+        ToolTipUtil.attachCustomTooltip(txtCardNumber, "Enter 16-digit card number");
+        txtCardNumber.setAlignmentX(Component.LEFT_ALIGNMENT);
+        pnlPaymentPanel.add(txtCardNumber);
+        pnlPaymentPanel.add(Box.createRigidArea(new Dimension(0, 10)));
 
         // Expiry & CVV Panel
-        JPanel expCvvPanel = new JPanel();
-        expCvvPanel.setLayout(new BoxLayout(expCvvPanel, BoxLayout.X_AXIS));
-        expCvvPanel.setOpaque(false);
-        expCvvPanel.setAlignmentX(Component.LEFT_ALIGNMENT);
+        JPanel pnlExpCvvPanel = new JPanel();
+        pnlExpCvvPanel.setLayout(new BoxLayout(pnlExpCvvPanel, BoxLayout.X_AXIS));
+        pnlExpCvvPanel.setOpaque(false);
+        pnlExpCvvPanel.setAlignmentX(Component.LEFT_ALIGNMENT);
 
-        expiryDate = createValidatedField("MM/YY", s -> {
+        txtExpiryDate = createValidatedField("MM/YY", s -> {
             if (!s.matches("^(0[1-9]|1[0-2])/\\d{2}$")) return false;
             try {
                 String[] parts = s.split("/");
@@ -475,25 +475,25 @@ public class AddConfirm extends JFrame {
                 return false;
             }
         });
-        SmartFieldFormatter.attachExpiryDateFormatter(expiryDate);
-        ((AbstractDocument) expiryDate.getDocument()).setDocumentFilter(new LengthLimitFilter(5));
-        ToolTipUtil.attachCustomTooltip(expiryDate, "Enter expiry date (MM/YY)");
-        expiryDate.setMaximumSize(new Dimension(100, 38));
-        expiryDate.setPreferredSize(new Dimension(100, 38));
-        expCvvPanel.add(expiryDate);
-        expCvvPanel.add(Box.createRigidArea(new Dimension(20, 0)));
+        SmartFieldFormatter.attachExpiryDateFormatter(txtExpiryDate);
+        ((AbstractDocument) txtExpiryDate.getDocument()).setDocumentFilter(new LengthLimitFilter(5));
+        ToolTipUtil.attachCustomTooltip(txtExpiryDate, "Enter expiry date (MM/YY)");
+        txtExpiryDate.setMaximumSize(new Dimension(100, 38));
+        txtExpiryDate.setPreferredSize(new Dimension(100, 38));
+        pnlExpCvvPanel.add(txtExpiryDate);
+        pnlExpCvvPanel.add(Box.createRigidArea(new Dimension(20, 0)));
 
-        cvv = createValidatedField("CVV", s -> s.matches("\\d{3,4}"));
-        ((AbstractDocument) cvv.getDocument()).setDocumentFilter(new LengthLimitFilter(4));
-        ToolTipUtil.attachCustomTooltip(cvv, "Enter CVV (3 or 4 digits)");
-        cvv.setMaximumSize(new Dimension(80, 38));
-        cvv.setPreferredSize(new Dimension(80, 38));
-        expCvvPanel.add(cvv);
+        txtCvv = createValidatedField("CVV", s -> s.matches("\\d{3,4}"));
+        ((AbstractDocument) txtCvv.getDocument()).setDocumentFilter(new LengthLimitFilter(4));
+        ToolTipUtil.attachCustomTooltip(txtCvv, "Enter CVV (3 or 4 digits)");
+        txtCvv.setMaximumSize(new Dimension(80, 38));
+        txtCvv.setPreferredSize(new Dimension(80, 38));
+        pnlExpCvvPanel.add(txtCvv);
 
-        paymentPanel.add(expCvvPanel);
-        paymentPanel.add(Box.createRigidArea(new Dimension(0, 40)));
+        pnlPaymentPanel.add(pnlExpCvvPanel);
+        pnlPaymentPanel.add(Box.createRigidArea(new Dimension(0, 40)));
 
-        return paymentPanel;
+        return pnlPaymentPanel;
     }
 
     private RoundedComponents.RoundedTextField createValidatedField(
@@ -504,7 +504,7 @@ public class AddConfirm extends JFrame {
         field.setFont(FontUtil.getOutfitFont(15f));
         field.setPreferredSize(new Dimension(175, 38));
         field.setMaximumSize(new Dimension(175, 38));
-        paymentFields.add(field);
+        lstPaymentFields.add(field);
         ValidationUtil.addTextValidation(field, validator);
         return field;
     }

--- a/application-system/src/main/java/com/group_9/project/AddPlansPage.java
+++ b/application-system/src/main/java/com/group_9/project/AddPlansPage.java
@@ -20,151 +20,151 @@ public class AddPlansPage extends JFrame {
 
     public AddPlansPage() {
         BaseFrameSetup.applyAppIcon(this);
-        BackgroundPanel background = BaseFrameSetup.setupCompleteFrame(this, 1);
+        BackgroundPanel pnlBackground = BaseFrameSetup.setupCompleteFrame(this, 1);
 
         // 2) White rounded container
-        JPanel container = new RoundedComponents.RoundedShadowPanel(25, 4);
-        container.setBounds(235, 165, 970, 695);
-        background.add(container);
+        JPanel pnlContainer = new RoundedComponents.RoundedShadowPanel(25, 4);
+        pnlContainer.setBounds(235, 165, 970, 695);
+        pnlBackground.add(pnlContainer);
 
         // 3) Inner content
-        JPanel inner = new JPanel();
-        inner.setLayout(new BoxLayout(inner, BoxLayout.Y_AXIS));
-        inner.setOpaque(false);
-        inner.setBounds(40, 40, 890, 615);
-        container.add(inner);
+        JPanel pnlInnerContent = new JPanel();
+        pnlInnerContent.setLayout(new BoxLayout(pnlInnerContent, BoxLayout.Y_AXIS));
+        pnlInnerContent.setOpaque(false);
+        pnlInnerContent.setBounds(40, 40, 890, 615);
+        pnlContainer.add(pnlInnerContent);
 
-        inner.add(Box.createRigidArea(new Dimension(0, 20)));
+        pnlInnerContent.add(Box.createRigidArea(new Dimension(0, 20)));
 
         // Title
-        JLabel title = new JLabel("SERVICE APPLICATION", SwingConstants.CENTER);
-        title.setFont(FontUtil.getOutfitBoldFont(26f));
-        title.setForeground(Color.decode("#2B0243"));
-        title.setAlignmentX(Component.CENTER_ALIGNMENT);
-        inner.add(title);
+        JLabel lblTitle = new JLabel("SERVICE APPLICATION", SwingConstants.CENTER);
+        lblTitle.setFont(FontUtil.getOutfitBoldFont(26f));
+        lblTitle.setForeground(Color.decode("#2B0243"));
+        lblTitle.setAlignmentX(Component.CENTER_ALIGNMENT);
+        pnlInnerContent.add(lblTitle);
 
-        inner.add(Box.createRigidArea(new Dimension(0, 20)));
+        pnlInnerContent.add(Box.createRigidArea(new Dimension(0, 20)));
 
         // Step tracker (step 1)
-        JPanel steps = new JPanel(new FlowLayout(FlowLayout.CENTER));
-        steps.setOpaque(false);
-        steps.add(CreateStepTracker.createStepTracker(1));
-        inner.add(steps);
+        JPanel pnlStepWrapper = new JPanel(new FlowLayout(FlowLayout.CENTER));
+        pnlStepWrapper.setOpaque(false);
+        pnlStepWrapper.add(CreateStepTracker.createStepTracker(1));
+        pnlInnerContent.add(pnlStepWrapper);
 
-        inner.add(Box.createRigidArea(new Dimension(0, 20)));
+        pnlInnerContent.add(Box.createRigidArea(new Dimension(0, 20)));
 
         // Subtitle + Note
         Color subColor = Color.decode("#302E2E");
-        JLabel subtitle = new JLabel("CHOOSE YOUR PLAN", SwingConstants.LEFT);
-        subtitle.setFont(FontUtil.getOutfitFont(16f));
-        subtitle.setForeground(subColor);
+        JLabel lblSubtitle = new JLabel("CHOOSE YOUR PLAN", SwingConstants.LEFT);
+        lblSubtitle.setFont(FontUtil.getOutfitFont(16f));
+        lblSubtitle.setForeground(subColor);
 
-        JLabel subNote = new JLabel(
+        JLabel lblSubNote = new JLabel(
             "Choose one or more plans to get started. You can also add more later."
         );
-        subNote.setFont(FontUtil.getInterFont(14f));
-        subNote.setForeground(subColor);
+        lblSubNote.setFont(FontUtil.getInterFont(14f));
+        lblSubNote.setForeground(subColor);
 
-        JPanel infoPanel = new JPanel(new BorderLayout());
-        infoPanel.setOpaque(false);
-        infoPanel.setMaximumSize(new Dimension(826, 60));
-        JPanel leftLabels = new JPanel();
-        leftLabels.setOpaque(false);
-        leftLabels.setLayout(new BoxLayout(leftLabels, BoxLayout.Y_AXIS));
-        leftLabels.add(subtitle);
-        leftLabels.add(Box.createRigidArea(new Dimension(0, 5)));
-        leftLabels.add(subNote);
-        infoPanel.add(leftLabels, BorderLayout.WEST);
-        inner.add(infoPanel);
+        JPanel pnlInfoPanel = new JPanel(new BorderLayout());
+        pnlInfoPanel.setOpaque(false);
+        pnlInfoPanel.setMaximumSize(new Dimension(826, 60));
+        JPanel pnlLeftLabels = new JPanel();
+        pnlLeftLabels.setOpaque(false);
+        pnlLeftLabels.setLayout(new BoxLayout(pnlLeftLabels, BoxLayout.Y_AXIS));
+        pnlLeftLabels.add(lblSubtitle);
+        pnlLeftLabels.add(Box.createRigidArea(new Dimension(0, 5)));
+        pnlLeftLabels.add(lblSubNote);
+        pnlInfoPanel.add(pnlLeftLabels, BorderLayout.WEST);
+        pnlInnerContent.add(pnlInfoPanel);
 
-        inner.add(Box.createRigidArea(new Dimension(0, 10)));
-        JSeparator sep = new JSeparator(SwingConstants.HORIZONTAL);
-        sep.setMaximumSize(new Dimension(826, 2));
-        sep.setForeground(Color.decode("#B2B2B2"));
-        sep.setAlignmentX(Component.CENTER_ALIGNMENT);
-        inner.add(sep);
-        inner.add(Box.createRigidArea(new Dimension(0, 20)));
+        pnlInnerContent.add(Box.createRigidArea(new Dimension(0, 10)));
+        JSeparator sepDivider = new JSeparator(SwingConstants.HORIZONTAL);
+        sepDivider.setMaximumSize(new Dimension(826, 2));
+        sepDivider.setForeground(Color.decode("#B2B2B2"));
+        sepDivider.setAlignmentX(Component.CENTER_ALIGNMENT);
+        pnlInnerContent.add(sepDivider);
+        pnlInnerContent.add(Box.createRigidArea(new Dimension(0, 20)));
 
         // 4) Plan grid
-        JPanel planGrid = new JPanel(new GridBagLayout());
-        planGrid.setOpaque(false);
-        planGrid.setMaximumSize(new Dimension(826, 350));
+        JPanel pnlPlanGrid = new JPanel(new GridBagLayout());
+        pnlPlanGrid.setOpaque(false);
+        pnlPlanGrid.setMaximumSize(new Dimension(826, 350));
         GridBagConstraints gbc = new GridBagConstraints();
         gbc.insets = new Insets(10, 20, 10, 20);
         gbc.fill   = GridBagConstraints.HORIZONTAL;
 
         // build the panels
-        ArrayList<SelectablePlanPanel> plans = new ArrayList<>();
-        plans.add(new SelectablePlanPanel("P001", "FIBERX 1500",       "₱1500", "Installation Fee: ₱125/24mo."));
-        plans.add(new SelectablePlanPanel("P002", "FIBER Xtream 4500", "₱4500", "Installation Fee: WAIVED"));
-        plans.add(new SelectablePlanPanel("P003", "FIBERX 2500",       "₱2500", "Installation Fee: ₱125/24mo."));
-        plans.add(new SelectablePlanPanel("P004", "FIBER Xtream 7000", "₱7000", "Installation Fee: WAIVED"));
-        plans.add(new SelectablePlanPanel("P005", "FIBERX 3500",       "₱3500", "Installation Fee: ₱125/12mo."));
+        ArrayList<SelectablePlanPanel> lstPlanPanels = new ArrayList<>();
+        lstPlanPanels.add(new SelectablePlanPanel("P001", "FIBERX 1500",       "₱1500", "Installation Fee: ₱125/24mo."));
+        lstPlanPanels.add(new SelectablePlanPanel("P002", "FIBER Xtream 4500", "₱4500", "Installation Fee: WAIVED"));
+        lstPlanPanels.add(new SelectablePlanPanel("P003", "FIBERX 2500",       "₱2500", "Installation Fee: ₱125/24mo."));
+        lstPlanPanels.add(new SelectablePlanPanel("P004", "FIBER Xtream 7000", "₱7000", "Installation Fee: WAIVED"));
+        lstPlanPanels.add(new SelectablePlanPanel("P005", "FIBERX 3500",       "₱3500", "Installation Fee: ₱125/12mo."));
 
         // fetch which ones the user already has
-        List<String> subscribedPlanIDs = fetchSubscribedPlanIDs(
+        List<String> lstSubscribedPlanIDs = fetchSubscribedPlanIDs(
             UserApplicationData.get("Username")
         );
 
         // lay them out, pre-select & disable those already subscribed
-        for (int i = 0; i < plans.size(); i++) {
-            SelectablePlanPanel p = plans.get(i);
+        for (int i = 0; i < lstPlanPanels.size(); i++) {
+            SelectablePlanPanel pnl = lstPlanPanels.get(i);
 
-            if (subscribedPlanIDs.contains(p.getPlanID())) {
-                p.setDisabled(true);
+            if (lstSubscribedPlanIDs.contains(pnl.getPlanID())) {
+                pnl.setDisabled(true);
             }
 
             gbc.gridx = i % 2;
             gbc.gridy = i / 2;
-            planGrid.add(p, gbc);
+            pnlPlanGrid.add(pnl, gbc);
 
             if (i == 4) {
                 gbc.gridx = 1;
-                JTextArea note = new JTextArea(
+                JTextArea txtNote = new JTextArea(
                     "*With outright Payment Option of Php 2,500 for\n" +
                     " Plans 1500 & 2500, and Php 1,250 for Plan 3500.\n" +
                     " Waived Installation Fee for Plans 4500 and 7000.\n" +
                     " *Prices are VAT Inclusive"
                 );
-                note.setFont(FontUtil.getOutfitFont(14f));
-                note.setOpaque(false);
-                note.setEditable(false);
-                planGrid.add(note, gbc);
+                txtNote.setFont(FontUtil.getOutfitFont(14f));
+                txtNote.setOpaque(false);
+                txtNote.setEditable(false);
+                pnlPlanGrid.add(txtNote, gbc);
             }
         }
 
         gbc.gridx      = 0;
         gbc.gridy++;
         gbc.gridwidth = 2;
-        inner.add(planGrid);
+        pnlInnerContent.add(pnlPlanGrid);
 
-        inner.add(Box.createRigidArea(new Dimension(0, 40)));
+        pnlInnerContent.add(Box.createRigidArea(new Dimension(0, 40)));
 
         // 5) NEXT button
-        JPanel btnPanel = new JPanel(new BorderLayout());
-        btnPanel.setOpaque(false);
-        btnPanel.setMaximumSize(new Dimension(826, 50));
-        RoundedComponents.RoundedButton next = new RoundedComponents.RoundedButton("NEXT", 25);
-        next.setPreferredSize(new Dimension(148, 41));
-        next.setBackground(Color.decode("#2B0243"));
-        next.setForeground(Color.WHITE);
-        next.setFont(FontUtil.getOutfitBoldFont(16f));
-        next.setBorderColor(Color.decode("#2B0243"));
-        btnPanel.add(next, BorderLayout.EAST);
-        inner.add(btnPanel);
+        JPanel pnlBtnPanel = new JPanel(new BorderLayout());
+        pnlBtnPanel.setOpaque(false);
+        pnlBtnPanel.setMaximumSize(new Dimension(826, 50));
+        RoundedComponents.RoundedButton cmdNext = new RoundedComponents.RoundedButton("NEXT", 25);
+        cmdNext.setPreferredSize(new Dimension(148, 41));
+        cmdNext.setBackground(Color.decode("#2B0243"));
+        cmdNext.setForeground(Color.WHITE);
+        cmdNext.setFont(FontUtil.getOutfitBoldFont(16f));
+        cmdNext.setBorderColor(Color.decode("#2B0243"));
+        pnlBtnPanel.add(cmdNext, BorderLayout.EAST);
+        pnlInnerContent.add(pnlBtnPanel);
 
-        next.addActionListener(e -> {
+        cmdNext.addActionListener(e -> {
             // only gather *new* selections (skip disabled ones)
-            ArrayList<String> newPlanTitles = new ArrayList<>();
-            ArrayList<String> newPlanIDs    = new ArrayList<>();
-            for (SelectablePlanPanel panel : plans) {
+            ArrayList<String> lstNewPlanTitles = new ArrayList<>();
+            ArrayList<String> lstNewPlanIDs    = new ArrayList<>();
+            for (SelectablePlanPanel panel : lstPlanPanels) {
                 if (panel.isSelected() && !panel.isDisabled()) {
-                    newPlanTitles.add(panel.getPlanTitle());
-                    newPlanIDs.add(panel.getPlanID());
+                    lstNewPlanTitles.add(panel.getPlanTitle());
+                    lstNewPlanIDs.add(panel.getPlanID());
                 }
             }
 
-            if (newPlanIDs.isEmpty()) {
+            if (lstNewPlanIDs.isEmpty()) {
                 CustomDialogUtil.showStyledErrorDialog(
                     AddPlansPage.this,
                     "No New Plan Selected",
@@ -174,8 +174,8 @@ public class AddPlansPage extends JFrame {
             }
 
             // re-check DB for conflicts (just in case)
-            String username = UserApplicationData.get("Username");
-            String sql = """
+            String strUsername = UserApplicationData.get("Username");
+            String strSql = """
                 SELECT s.service_plan
                   FROM tbl_payment p
                   JOIN tbl_application a ON p.application_no = a.application_no
@@ -186,10 +186,10 @@ public class AddPlansPage extends JFrame {
             """;
 
             try (Connection conn = DatabaseConnection.getConnection();
-                 PreparedStatement ps = conn.prepareStatement(sql)) {
+                 PreparedStatement ps = conn.prepareStatement(strSql)) {
 
-                ps.setString(1, username);
-                for (String planId : newPlanIDs) {
+                ps.setString(1, strUsername);
+                for (String planId : lstNewPlanIDs) {
                     ps.setString(2, planId);
                     try (ResultSet rs = ps.executeQuery()) {
                         if (rs.next()) {
@@ -214,21 +214,21 @@ public class AddPlansPage extends JFrame {
             }
 
             // save *only* the new ones
-            UserApplicationData.set("selectedPlans",   String.join(",", newPlanTitles));
-            UserApplicationData.set("selectedPlanIDs", String.join(",", newPlanIDs));
+            UserApplicationData.set("selectedPlans",   String.join(",", lstNewPlanTitles));
+            UserApplicationData.set("selectedPlanIDs", String.join(",", lstNewPlanIDs));
 
             new AddConfirm().setVisible(true);
             dispose();
         });
 
         setVisible(true);
-        SwingUtilities.invokeLater(() -> background.requestFocusInWindow());
+        SwingUtilities.invokeLater(() -> pnlBackground.requestFocusInWindow());
     }
 
     /** Helper to fetch all plan_IDs this user already has paid for. */
-    private List<String> fetchSubscribedPlanIDs(String username) {
-        List<String> list = new ArrayList<>();
-        String sql =
+    private List<String> fetchSubscribedPlanIDs(String strUsername) {
+        List<String> lstIDs = new ArrayList<>();
+        String strSql =
             "SELECT p.plan_ID " +
             "  FROM tbl_payment p " +
             "  JOIN tbl_application a ON p.application_no = a.application_no " +
@@ -236,19 +236,19 @@ public class AddPlansPage extends JFrame {
             " WHERE c.username = ?";
 
         try (Connection conn = DatabaseConnection.getConnection();
-             PreparedStatement ps = conn.prepareStatement(sql)) {
+             PreparedStatement ps = conn.prepareStatement(strSql)) {
 
-            ps.setString(1, username);
+            ps.setString(1, strUsername);
             try (ResultSet rs = ps.executeQuery()) {
                 while (rs.next()) {
-                    list.add(rs.getString("plan_ID"));
+                    lstIDs.add(rs.getString("plan_ID"));
                 }
             }
         } catch (SQLException ex) {
             ex.printStackTrace();
             // optionally show a dialog here
         }
-        return list;
+        return lstIDs;
     }
 
 

--- a/application-system/src/main/java/com/group_9/project/ErrorPage.java
+++ b/application-system/src/main/java/com/group_9/project/ErrorPage.java
@@ -15,43 +15,43 @@ public class ErrorPage extends JFrame {
 
     public ErrorPage() {
         BaseFrameSetup.applyAppIcon(this);
-        BackgroundPanel background = BaseFrameSetup.setupCompleteFrame(this, 3);
+        BackgroundPanel pnlBackground = BaseFrameSetup.setupCompleteFrame(this, 3);
 
         // 404 Message
 
-        int yPos = 350;
+        int intYPos = 350;
 
-        JLabel errorCode = new JLabel("<html><div style='font-weight:800;'>404</div></html>", SwingConstants.CENTER);
-        errorCode.setFont(FontUtil.getOutfitBoldFont(120f).deriveFont(Font.BOLD));
-        errorCode.setForeground(new Color(42, 2, 67));
-        errorCode.setBounds(0, yPos, 1424, 100);
-        background.add(errorCode);
+        JLabel lblErrorCode = new JLabel("<html><div style='font-weight:800;'>404</div></html>", SwingConstants.CENTER);
+        lblErrorCode.setFont(FontUtil.getOutfitBoldFont(120f).deriveFont(Font.BOLD));
+        lblErrorCode.setForeground(new Color(42, 2, 67));
+        lblErrorCode.setBounds(0, intYPos, 1424, 100);
+        pnlBackground.add(lblErrorCode);
 
-        JLabel message = new JLabel("Oops... This page is not found.", SwingConstants.CENTER);
-        message.setFont(FontUtil.getOutfitFont(40f));
-        message.setForeground(new Color(42, 2, 67));
-        message.setBounds(0, yPos + 100, 1424, 45);
-        background.add(message);
+        JLabel lblMessage = new JLabel("Oops... This page is not found.", SwingConstants.CENTER);
+        lblMessage.setFont(FontUtil.getOutfitFont(40f));
+        lblMessage.setForeground(new Color(42, 2, 67));
+        lblMessage.setBounds(0, intYPos + 100, 1424, 45);
+        pnlBackground.add(lblMessage);
 
         // Container panel to center both labels
-        JPanel returnPanel = new JPanel(new FlowLayout(FlowLayout.CENTER, 0, 0));
-        returnPanel.setOpaque(false);
-        returnPanel.setBounds(0, yPos + 165, 1424, 30);
+        JPanel pnlReturn = new JPanel(new FlowLayout(FlowLayout.CENTER, 0, 0));
+        pnlReturn.setOpaque(false);
+        pnlReturn.setBounds(0, intYPos + 165, 1424, 30);
 
         // "Return to " (normal text)
-        JLabel returnText = new JLabel("Return to ");
-        returnText.setFont(FontUtil.getInterFont(18f));
-        returnText.setForeground(Color.DARK_GRAY);
-        returnPanel.add(returnText);
+        JLabel lblReturnText = new JLabel("Return to ");
+        lblReturnText.setFont(FontUtil.getInterFont(18f));
+        lblReturnText.setForeground(Color.DARK_GRAY);
+        pnlReturn.add(lblReturnText);
 
         // "home page" (clickable link)
-        JLabel homeLink = new JLabel("<html><u>home page</u></html>");
-        homeLink.setFont(FontUtil.getInterFont(18f));
-        homeLink.setForeground(new Color(62, 10, 118));
-        homeLink.setCursor(Cursor.getPredefinedCursor(Cursor.HAND_CURSOR));
+        JLabel lblHomeLink = new JLabel("<html><u>home page</u></html>");
+        lblHomeLink.setFont(FontUtil.getInterFont(18f));
+        lblHomeLink.setForeground(new Color(62, 10, 118));
+        lblHomeLink.setCursor(Cursor.getPredefinedCursor(Cursor.HAND_CURSOR));
 
         // Open Homepage and close ErrorPage when clicked
-        homeLink.addMouseListener(new java.awt.event.MouseAdapter() {
+        lblHomeLink.addMouseListener(new java.awt.event.MouseAdapter() {
             @Override
             public void mouseClicked(java.awt.event.MouseEvent e) {
                 String appNo = UserApplicationData.get("ApplicationNo");
@@ -63,10 +63,10 @@ public class ErrorPage extends JFrame {
             }
         });
 
-        returnPanel.add(homeLink);
+        pnlReturn.add(lblHomeLink);
 
         // Add combined panel
-        background.add(returnPanel);
+        pnlBackground.add(pnlReturn);
     }
 
     public static void main(String[] args) {

--- a/application-system/src/main/java/com/group_9/project/HelpSupportPage.java
+++ b/application-system/src/main/java/com/group_9/project/HelpSupportPage.java
@@ -16,47 +16,47 @@ public class HelpSupportPage extends JFrame {
 
     public HelpSupportPage() {
         BaseFrameSetup.applyAppIcon(this);
-        BackgroundPanel background = BaseFrameSetup.setupCompleteFrame(this, 1);
+        BackgroundPanel pnlBackground = BaseFrameSetup.setupCompleteFrame(this, 1);
 
         // Page headline
-        JLabel headline = new JLabel("Hello, How Can We Help You?", SwingConstants.CENTER);
-        headline.setFont(FontUtil.getOutfitBoldFont(50f).deriveFont(Font.BOLD));
-        headline.setForeground(new Color(42, 2, 67));
-        headline.setBounds(0, 160, 1424, 50);
-        background.add(headline);
+        JLabel lblHeadline = new JLabel("Hello, How Can We Help You?", SwingConstants.CENTER);
+        lblHeadline.setFont(FontUtil.getOutfitBoldFont(50f).deriveFont(Font.BOLD));
+        lblHeadline.setForeground(new Color(42, 2, 67));
+        lblHeadline.setBounds(0, 160, 1424, 50);
+        pnlBackground.add(lblHeadline);
 
         // Search Field Panel
-        JPanel searchPanel = new JPanel(null);
-        searchPanel.setBounds(325, 230, 775, 60); 
-        searchPanel.setOpaque(false);
-        searchPanel.setLayout(null);
+        JPanel pnlSearchPanel = new JPanel(null);
+        pnlSearchPanel.setBounds(325, 230, 775, 60);
+        pnlSearchPanel.setOpaque(false);
+        pnlSearchPanel.setLayout(null);
 
         // Rounded Search Field (shortened to leave space for icon)
-        RoundedTextField searchField = new RoundedTextField("Search your keyword here...", 20);
-        searchField.setFont(FontUtil.getInterFont(20f));
-        searchField.setForeground(Color.BLACK);
-        searchField.setBounds(0, 0, 775, 60);
-        searchField.setBackground(new Color(255, 255, 255, 180));
-        searchPanel.add(searchField);
+        RoundedTextField txtSearchField = new RoundedTextField("Search your keyword here...", 20);
+        txtSearchField.setFont(FontUtil.getInterFont(20f));
+        txtSearchField.setForeground(Color.BLACK);
+        txtSearchField.setBounds(0, 0, 775, 60);
+        txtSearchField.setBackground(new Color(255, 255, 255, 180));
+        pnlSearchPanel.add(txtSearchField);
 
-        searchField.setFocusable(false);
-        SwingUtilities.invokeLater(() -> searchField.setFocusable(true));
+        txtSearchField.setFocusable(false);
+        SwingUtilities.invokeLater(() -> txtSearchField.setFocusable(true));
         
         ImageIcon rawIcon = new ImageIcon(getClass().getClassLoader().getResource("icons/search.png"));
         Image scaled = rawIcon.getImage().getScaledInstance(30, 30, Image.SCALE_SMOOTH);
         ImageIcon resizedIcon = new ImageIcon(scaled);
 
         // Create icon label
-        JLabel searchIcon = new JLabel(resizedIcon);
+        JLabel lblSearchIcon = new JLabel(resizedIcon);
         int iconSize = 30;
         int iconX = 775 - iconSize - 20; 
         int iconY = (60 - iconSize) / 2; 
 
-        searchIcon.setBounds(iconX, iconY, iconSize, iconSize);
-        searchPanel.add(searchIcon);
+        lblSearchIcon.setBounds(iconX, iconY, iconSize, iconSize);
+        pnlSearchPanel.add(lblSearchIcon);
 
 
-        background.add(searchPanel);
+        pnlBackground.add(pnlSearchPanel);
 
 
         // Cards container
@@ -78,49 +78,49 @@ public class HelpSupportPage extends JFrame {
         int startX = 92; 
         
         for (int i = 0; i < 3; i++) {
-            RoundedPanel card = new RoundedPanel(30);
-            card.setBounds(startX + i * (cardWidth + spacingBetweenCards), 350, cardWidth, cardHeight);
-            card.setBackground(Color.WHITE);
-            card.setLayout(null);
+            RoundedPanel pnlCard = new RoundedPanel(30);
+            pnlCard.setBounds(startX + i * (cardWidth + spacingBetweenCards), 350, cardWidth, cardHeight);
+            pnlCard.setBackground(Color.WHITE);
+            pnlCard.setLayout(null);
             
             // Icon (120x120 centered)
             ImageIcon icon = new ImageIcon(getClass().getClassLoader().getResource(iconPaths[i]));
             Image img = icon.getImage().getScaledInstance(120, 120, Image.SCALE_SMOOTH);
-            JLabel iconLabel = new JLabel(new ImageIcon(img));
-            iconLabel.setBounds((cardWidth - 120) / 2, 15, 120, 120);
-            card.add(iconLabel);
+            JLabel lblIcon = new JLabel(new ImageIcon(img));
+            lblIcon.setBounds((cardWidth - 120) / 2, 15, 120, 120);
+            pnlCard.add(lblIcon);
         
             // Title
-            JLabel titleLabel = new JLabel(titles[i], SwingConstants.CENTER);
-            titleLabel.setFont(FontUtil.getOutfitBoldFont(26f).deriveFont(Font.BOLD));
-            titleLabel.setForeground(new Color(42, 2, 67));
-            titleLabel.setBounds(0, 145, cardWidth, 35);
-            card.add(titleLabel);
+            JLabel lblTitle = new JLabel(titles[i], SwingConstants.CENTER);
+            lblTitle.setFont(FontUtil.getOutfitBoldFont(26f).deriveFont(Font.BOLD));
+            lblTitle.setForeground(new Color(42, 2, 67));
+            lblTitle.setBounds(0, 145, cardWidth, 35);
+            pnlCard.add(lblTitle);
         
             // Description
-            JLabel descLabel = new JLabel(descriptions[i], SwingConstants.CENTER);
-            descLabel.setFont(FontUtil.getInterFont(15f));
-            descLabel.setForeground(Color.DARK_GRAY);
-            descLabel.setBounds(25, 185, cardWidth - 50, 100); // horizontal padding
-            card.add(descLabel);
+            JLabel lblDesc = new JLabel(descriptions[i], SwingConstants.CENTER);
+            lblDesc.setFont(FontUtil.getInterFont(15f));
+            lblDesc.setForeground(Color.DARK_GRAY);
+            lblDesc.setBounds(25, 185, cardWidth - 50, 100); // horizontal padding
+            pnlCard.add(lblDesc);
         
-            background.add(card);
+            pnlBackground.add(pnlCard);
         }
         
         
 
         // Footer link
-        JLabel footer = new JLabel(
+        JLabel lblFooter = new JLabel(
             "<html><div style='text-align:center;'>" +
             "<span style='font-weight:500;color:#1E1E1E;'>Have more questions? </span>" +
             "<span style='font-weight:500;color:#623CBB;'>Submit a Request</span>" +
             "</div></html>",
             SwingConstants.CENTER
         );
-        footer.setFont(FontUtil.getInterFont(26f));
-        footer.setBounds(0, 750, 1440, 30);
-        footer.setCursor(Cursor.getPredefinedCursor(Cursor.HAND_CURSOR));
-        background.add(footer);
+        lblFooter.setFont(FontUtil.getInterFont(26f));
+        lblFooter.setBounds(0, 750, 1440, 30);
+        lblFooter.setCursor(Cursor.getPredefinedCursor(Cursor.HAND_CURSOR));
+        pnlBackground.add(lblFooter);
         
     }
 

--- a/application-system/src/main/java/com/group_9/project/Homepage.java
+++ b/application-system/src/main/java/com/group_9/project/Homepage.java
@@ -12,29 +12,29 @@ public class Homepage extends JFrame {
 
     public Homepage() {
     BaseFrameSetup.applyAppIcon(this);
-    BackgroundPanel background = BaseFrameSetup.setupCompleteFrame(this, 1);
+    BackgroundPanel pnlBackground = BaseFrameSetup.setupCompleteFrame(this, 1);
                 
 
         // Main headline - enlarged and repositioned
-        JLabel headline = new JLabel("<html><div style='text-align:center;color:#2B0243;font-weight:700;'>Supercharge your home with<br>ultra-fast internet and endless entertainment.</div></html>", SwingConstants.CENTER);
-        headline.setFont(FontUtil.getOutfitFont(50f));
-        headline.setForeground(new Color(0x2B0243));
-        headline.setBounds(112, 220, 1200, 120);
-        background.add(headline);
+        JLabel lblHeadline = new JLabel("<html><div style='text-align:center;color:#2B0243;font-weight:700;'>Supercharge your home with<br>ultra-fast internet and endless entertainment.</div></html>", SwingConstants.CENTER);
+        lblHeadline.setFont(FontUtil.getOutfitFont(50f));
+        lblHeadline.setForeground(new Color(0x2B0243));
+        lblHeadline.setBounds(112, 220, 1200, 120);
+        pnlBackground.add(lblHeadline);
 
-        JLabel subHeadline = new JLabel("Enjoy faster speed, and incredible value with our plans.", SwingConstants.CENTER);
-        subHeadline.setFont(FontUtil.getInterFont(16f));
-        subHeadline.setBounds(420, 350, 600, 30);
-        background.add(subHeadline);
+        JLabel lblSubHeadline = new JLabel("Enjoy faster speed, and incredible value with our plans.", SwingConstants.CENTER);
+        lblSubHeadline.setFont(FontUtil.getInterFont(16f));
+        lblSubHeadline.setBounds(420, 350, 600, 30);
+        pnlBackground.add(lblSubHeadline);
 
-        JButton viewPlans = new JButton("VIEW PLANS");
-        viewPlans.setFont(FontUtil.getOutfitFont(16f).deriveFont(Font.BOLD));
-        viewPlans.setBounds(530, 400, 160, 45);
-        viewPlans.setFocusPainted(false);
-        ButtonHoverEffect.apply(viewPlans, new Color(62, 10, 118), Color.WHITE,
+        JButton cmdViewPlans = new JButton("VIEW PLANS");
+        cmdViewPlans.setFont(FontUtil.getOutfitFont(16f).deriveFont(Font.BOLD));
+        cmdViewPlans.setBounds(530, 400, 160, 45);
+        cmdViewPlans.setFocusPainted(false);
+        ButtonHoverEffect.apply(cmdViewPlans, new Color(62, 10, 118), Color.WHITE,
                 new Color(42, 2, 67), Color.WHITE, new Color(62, 10, 118), new Color(42, 2, 67));
-        
-        viewPlans.addActionListener(new ActionListener() {
+
+        cmdViewPlans.addActionListener(new ActionListener() {
             @Override
             public void actionPerformed(ActionEvent e) {
                 new PlansPage().setVisible(true);
@@ -43,24 +43,24 @@ public class Homepage extends JFrame {
         });
                 
         
-        background.add(viewPlans);
+        pnlBackground.add(cmdViewPlans);
         
-        JButton checkAvailability = new JButton("CHECK AVAILABILITY");
-        checkAvailability.setFont(FontUtil.getOutfitFont(16f).deriveFont(Font.BOLD));
-        checkAvailability.setBounds(700, 400, 220, 45);
-        checkAvailability.setFocusPainted(false);
-        checkAvailability.setContentAreaFilled(false);
+        JButton cmdCheckAvailability = new JButton("CHECK AVAILABILITY");
+        cmdCheckAvailability.setFont(FontUtil.getOutfitFont(16f).deriveFont(Font.BOLD));
+        cmdCheckAvailability.setBounds(700, 400, 220, 45);
+        cmdCheckAvailability.setFocusPainted(false);
+        cmdCheckAvailability.setContentAreaFilled(false);
         ButtonHoverEffect.apply(
-                                checkAvailability, 
-                                new Color(62, 10, 118), 
+                                cmdCheckAvailability,
                                 new Color(62, 10, 118),
-                                new Color(0, 0, 0, 0), 
-                                new Color(38, 6, 67), 
-                                new Color(62, 10, 118), 
+                                new Color(62, 10, 118),
+                                new Color(0, 0, 0, 0),
+                                new Color(38, 6, 67),
+                                new Color(62, 10, 118),
                                 new Color(42, 2, 67)
         );
-        
-        checkAvailability.addActionListener(new ActionListener() {
+
+        cmdCheckAvailability.addActionListener(new ActionListener() {
             @Override
             public void actionPerformed(ActionEvent e) {
                 new ErrorPage().setVisible(true);
@@ -69,29 +69,29 @@ public class Homepage extends JFrame {
         });
         
         
-        background.add(checkAvailability);
+        pnlBackground.add(cmdCheckAvailability);
 
         // Apply Now Section
-        int applyX = 205;
-        int applyY = 535;
-        int applyWidth = 520;
+        int intApplyX = 205;
+        int intApplyY = 535;
+        int intApplyWidth = 520;
 
-        JLabel applyNow = new JLabel("<html><div style='font-weight:600;color:#2B0243;'>Apply Now!</div></html>", SwingConstants.LEFT);
-        applyNow.setFont(FontUtil.getInterFont(35f));
-        applyNow.setBounds(applyX, applyY, applyWidth, 40);
-        background.add(applyNow);
+        JLabel lblApplyNow = new JLabel("<html><div style='font-weight:600;color:#2B0243;'>Apply Now!</div></html>", SwingConstants.LEFT);
+        lblApplyNow.setFont(FontUtil.getInterFont(35f));
+        lblApplyNow.setBounds(intApplyX, intApplyY, intApplyWidth, 40);
+        pnlBackground.add(lblApplyNow);
 
-        JLabel applyDesc = new JLabel("<html>The process is simple, guided, and built for you.<br>Apply at your own pace, anytime.</html>");
-        applyDesc.setFont(FontUtil.getOutfitFont(16f));
-        applyDesc.setBounds(applyX, applyY + 50, applyWidth, 50);
-        background.add(applyDesc);
+        JLabel lblApplyDesc = new JLabel("<html>The process is simple, guided, and built for you.<br>Apply at your own pace, anytime.</html>");
+        lblApplyDesc.setFont(FontUtil.getOutfitFont(16f));
+        lblApplyDesc.setBounds(intApplyX, intApplyY + 50, intApplyWidth, 50);
+        pnlBackground.add(lblApplyDesc);
 
-        JButton getStarted = new RoundedComponents.RoundedButton("GET STARTED", 20);
-        getStarted.setFont(FontUtil.getOutfitFont(16f).deriveFont(Font.BOLD));
-        getStarted.setBounds(applyX, applyY + 105, 160, 45);
-        getStarted.setFocusPainted(false);
+        JButton cmdGetStarted = new RoundedComponents.RoundedButton("GET STARTED", 20);
+        cmdGetStarted.setFont(FontUtil.getOutfitFont(16f).deriveFont(Font.BOLD));
+        cmdGetStarted.setBounds(intApplyX, intApplyY + 105, 160, 45);
+        cmdGetStarted.setFocusPainted(false);
         ButtonHoverEffect.apply(
-                                getStarted, 
+                                cmdGetStarted,
                                 new Color(62, 10, 118),          //hover bg
                                 Color.WHITE,                           //hover fg
                                 new Color(42, 2, 67),            //normal bg
@@ -99,9 +99,9 @@ public class Homepage extends JFrame {
                                 new Color(62, 10, 118),          //hover border
                                 new Color(42, 2, 67)             //normal border
         );
-        background.add(getStarted);
+        pnlBackground.add(cmdGetStarted);
 
-        getStarted.addActionListener(new ActionListener() {
+        cmdGetStarted.addActionListener(new ActionListener() {
             @Override
             public void actionPerformed(ActionEvent e) {
                 String appNo = UserApplicationData.get("ApplicationNo");
@@ -116,31 +116,31 @@ public class Homepage extends JFrame {
         
 
         // Left text (not clickable)
-        JLabel promptText = new JLabel("Already have an account?");
-        promptText.setFont(FontUtil.getInterFont(16f));
-        promptText.setBounds(applyX, applyY + 155, 200, 30);
-        background.add(promptText);
+        JLabel lblPromptText = new JLabel("Already have an account?");
+        lblPromptText.setFont(FontUtil.getInterFont(16f));
+        lblPromptText.setBounds(intApplyX, intApplyY + 155, 200, 30);
+        pnlBackground.add(lblPromptText);
 
         // Clickable "Log in!" part
-        JLabel loginClickable = new JLabel(" Log in!");
-        loginClickable.setFont(FontUtil.getInterFont(16f));
+        JLabel lblLoginClickable = new JLabel(" Log in!");
+        lblLoginClickable.setFont(FontUtil.getInterFont(16f));
         
         Color normalColor = new Color(22, 6, 48, 128);
         Color hoverColor = new Color(62, 10, 118);
 
-        loginClickable.setForeground(normalColor);
-        loginClickable.setCursor(Cursor.getPredefinedCursor(Cursor.HAND_CURSOR));
-        loginClickable.setBounds(applyX + 200, applyY + 155, 60, 30);
+        lblLoginClickable.setForeground(normalColor);
+        lblLoginClickable.setCursor(Cursor.getPredefinedCursor(Cursor.HAND_CURSOR));
+        lblLoginClickable.setBounds(intApplyX + 200, intApplyY + 155, 60, 30);
         
-        loginClickable.addMouseListener(new java.awt.event.MouseAdapter() {
+        lblLoginClickable.addMouseListener(new java.awt.event.MouseAdapter() {
             @Override
             public void mouseEntered(java.awt.event.MouseEvent e) {
-                loginClickable.setForeground(hoverColor);
+                lblLoginClickable.setForeground(hoverColor);
             }
         
             @Override
             public void mouseExited(java.awt.event.MouseEvent e) {
-                loginClickable.setForeground(normalColor);
+                lblLoginClickable.setForeground(normalColor);
             }
         
             @Override
@@ -150,15 +150,15 @@ public class Homepage extends JFrame {
             }
         });
         
-        background.add(loginClickable);
+        pnlBackground.add(lblLoginClickable);
              
 
         // Steps Panel
-        RoundedPanel stepsPanel = new RoundedPanel(30);
-        stepsPanel.setLayout(null);
-        stepsPanel.setBounds(700, 520, 520, 320);
-        stepsPanel.setBackground(new Color(255, 255, 255, 180));
-        background.add(stepsPanel);
+        RoundedPanel pnlSteps = new RoundedPanel(30);
+        pnlSteps.setLayout(null);
+        pnlSteps.setBounds(700, 520, 520, 320);
+        pnlSteps.setBackground(new Color(255, 255, 255, 180));
+        pnlBackground.add(pnlSteps);
         
 
         String[] stepTitles = {
@@ -175,39 +175,39 @@ public class Homepage extends JFrame {
         for (int i = 0; i < stepTitles.length; i++) {
             int y = i * 75 + 25;
         
-            JLabel number = new JLabel(String.valueOf(i + 1), SwingConstants.CENTER);
-            number.setBounds(30, y, 43, 43);
-            number.setOpaque(false); // disable default opaque rect rendering
-            number.setFont(FontUtil.getOutfitFont(20f));
+            JLabel lblNumber = new JLabel(String.valueOf(i + 1), SwingConstants.CENTER);
+            lblNumber.setBounds(30, y, 43, 43);
+            lblNumber.setOpaque(false); // disable default opaque rect rendering
+            lblNumber.setFont(FontUtil.getOutfitFont(20f));
         
             if (i == 0) {
-                number.setBackground(new Color(255, 241, 255));
-                number.setForeground(new Color(80, 0, 128));
-                number.setUI(new RoundedLabelUI(40, new Color(126, 76, 165)));
+                lblNumber.setBackground(new Color(255, 241, 255));
+                lblNumber.setForeground(new Color(80, 0, 128));
+                lblNumber.setUI(new RoundedLabelUI(40, new Color(126, 76, 165)));
             } else {
-                number.setBackground(new Color(42, 2, 67));
-                number.setForeground(new Color(255, 241, 255));
-                number.setUI(new RoundedLabelUI(40, new Color(42, 2, 67))); // purple w/ border
+                lblNumber.setBackground(new Color(42, 2, 67));
+                lblNumber.setForeground(new Color(255, 241, 255));
+                lblNumber.setUI(new RoundedLabelUI(40, new Color(42, 2, 67))); // purple w/ border
             }
-        
-            stepsPanel.add(number);
+
+            pnlSteps.add(lblNumber);
         
             if (i < stepTitles.length - 1) {
-                JPanel connector = new JPanel();
-                connector.setBackground(new Color(126, 76, 165));
-                connector.setBounds(48, y + 40, 4, 35);
-                stepsPanel.add(connector);
+                JPanel pnlConnector = new JPanel();
+                pnlConnector.setBackground(new Color(126, 76, 165));
+                pnlConnector.setBounds(48, y + 40, 4, 35);
+                pnlSteps.add(pnlConnector);
             }
-        
-            JLabel title = new JLabel(stepTitles[i]);
-            title.setFont(FontUtil.getOutfitFont(18f).deriveFont(Font.BOLD));
-            title.setBounds(90, y, 420, 25);
-            stepsPanel.add(title);
-        
-            JLabel description = new JLabel(stepDescriptions[i]);
-            description.setFont(FontUtil.getOutfitFont(15f));
-            description.setBounds(90, y + 15, 420, 30);
-            stepsPanel.add(description);
+
+            JLabel lblStepTitle = new JLabel(stepTitles[i]);
+            lblStepTitle.setFont(FontUtil.getOutfitFont(18f).deriveFont(Font.BOLD));
+            lblStepTitle.setBounds(90, y, 420, 25);
+            pnlSteps.add(lblStepTitle);
+
+            JLabel lblStepDescription = new JLabel(stepDescriptions[i]);
+            lblStepDescription.setFont(FontUtil.getOutfitFont(15f));
+            lblStepDescription.setBounds(90, y + 15, 420, 30);
+            pnlSteps.add(lblStepDescription);
         }
         
         

--- a/application-system/src/main/java/com/group_9/project/LoginPage.java
+++ b/application-system/src/main/java/com/group_9/project/LoginPage.java
@@ -18,51 +18,51 @@ public class LoginPage extends JFrame {
         BaseFrameSetup.applyAppIcon(this);
         BaseFrameSetup.setupFrame(this);
 
-        BackgroundPanel background = BaseFrameSetup.createBackgroundPanel(1);
-        setContentPane(background);
-        BaseFrameSetup.createLogo(background);
-        BaseFrameSetup.createNavigation(background, this);
+        BackgroundPanel pnlBackground = BaseFrameSetup.createBackgroundPanel(1);
+        setContentPane(pnlBackground);
+        BaseFrameSetup.createLogo(pnlBackground);
+        BaseFrameSetup.createNavigation(pnlBackground, this);
 
-        JLabel headline = new JLabel("<html><div style='text-align:center;color:#2B0243;font-weight:700;'>Supercharge your home with<br>ultra-fast internet and endless entertainment.</div></html>", SwingConstants.CENTER);
-        headline.setFont(FontUtil.getOutfitFont(50f));
-        headline.setForeground(new Color(0x2B0243));
-        headline.setBounds(112, 220, 1200, 120);
-        background.add(headline);
+        JLabel lblHeadline = new JLabel("<html><div style='text-align:center;color:#2B0243;font-weight:700;'>Supercharge your home with<br>ultra-fast internet and endless entertainment.</div></html>", SwingConstants.CENTER);
+        lblHeadline.setFont(FontUtil.getOutfitFont(50f));
+        lblHeadline.setForeground(new Color(0x2B0243));
+        lblHeadline.setBounds(112, 220, 1200, 120);
+        pnlBackground.add(lblHeadline);
 
-        JLabel subHeadline = new JLabel("Enjoy faster speed, and incredible value with our plans.", SwingConstants.CENTER);
-        subHeadline.setFont(FontUtil.getInterFont(16f));
-        subHeadline.setBounds(420, 350, 600, 30);
-        background.add(subHeadline);
+        JLabel lblSubHeadline = new JLabel("Enjoy faster speed, and incredible value with our plans.", SwingConstants.CENTER);
+        lblSubHeadline.setFont(FontUtil.getInterFont(16f));
+        lblSubHeadline.setBounds(420, 350, 600, 30);
+        pnlBackground.add(lblSubHeadline);
 
-        int yPosi = 435;
+        int intYPos = 435;
 
-        JLabel letsLabel = new JLabel("<html><div style='text-align:center;color:#2B0243;font-weight:600;'>Let’s make things happen.</div></html>");
-        letsLabel.setFont(FontUtil.getOutfitFont(16f));
-        letsLabel.setBounds(562, yPosi, 300, 30);
-        letsLabel.setHorizontalAlignment(SwingConstants.CENTER);
-        background.add(letsLabel);
+        JLabel lblLets = new JLabel("<html><div style='text-align:center;color:#2B0243;font-weight:600;'>Let’s make things happen.</div></html>");
+        lblLets.setFont(FontUtil.getOutfitFont(16f));
+        lblLets.setBounds(562, intYPos, 300, 30);
+        lblLets.setHorizontalAlignment(SwingConstants.CENTER);
+        pnlBackground.add(lblLets);
 
-        RoundedComponents.RoundedTextField emailField = new RoundedComponents.RoundedTextField("Username or email", 20);
-        emailField.setFont(FontUtil.getInterFont(14f));
-        emailField.setBounds(524, yPosi + 40, 375, 60);
-        background.add(emailField);
+        RoundedComponents.RoundedTextField txtEmailField = new RoundedComponents.RoundedTextField("Username or email", 20);
+        txtEmailField.setFont(FontUtil.getInterFont(14f));
+        txtEmailField.setBounds(524, intYPos + 40, 375, 60);
+        pnlBackground.add(txtEmailField);
 
-        RoundedComponents.RoundedPasswordField passwordField = new RoundedComponents.RoundedPasswordField("Password", 20);
-        passwordField.setFont(FontUtil.getInterFont(14f));
-        passwordField.setBounds(524, yPosi + 117, 375, 60);
-        background.add(passwordField);
+        RoundedComponents.RoundedPasswordField txtPassword = new RoundedComponents.RoundedPasswordField("Password", 20);
+        txtPassword.setFont(FontUtil.getInterFont(14f));
+        txtPassword.setBounds(524, intYPos + 117, 375, 60);
+        pnlBackground.add(txtPassword);
 
         // ➕ Add validation
-        ValidationUtil.addTextValidation(emailField, s -> !s.trim().isEmpty());
-        ValidationUtil.addTextValidation(passwordField, s -> !s.trim().isEmpty());
+        ValidationUtil.addTextValidation(txtEmailField, s -> !s.trim().isEmpty());
+        ValidationUtil.addTextValidation(txtPassword, s -> !s.trim().isEmpty());
 
-        JButton loginBtn = new RoundedComponents.RoundedButton("LOG IN", 20);
-        loginBtn.setFont(FontUtil.getOutfitFont(16f));
-        loginBtn.setBounds(525, yPosi + 195, 130, 40);
-        loginBtn.setFocusPainted(false);
-        loginBtn.setFocusable(false);
+        JButton cmdLogin = new RoundedComponents.RoundedButton("LOG IN", 20);
+        cmdLogin.setFont(FontUtil.getOutfitFont(16f));
+        cmdLogin.setBounds(525, intYPos + 195, 130, 40);
+        cmdLogin.setFocusPainted(false);
+        cmdLogin.setFocusable(false);
         ButtonHoverEffect.apply(
-                loginBtn,
+                cmdLogin,
                 new Color(62, 10, 118),
                 Color.WHITE,
                 new Color(42, 2, 67),
@@ -70,29 +70,29 @@ public class LoginPage extends JFrame {
                 new Color(62, 10, 118),
                 new Color(42, 2, 67)
         );
-        background.add(loginBtn);
+        pnlBackground.add(cmdLogin);
 
-        ToolTipUtil.attachCustomTooltip(emailField, "Enter your username or email");
-        ToolTipUtil.attachCustomTooltip(passwordField, "Enter your password");
+        ToolTipUtil.attachCustomTooltip(txtEmailField, "Enter your username or email");
+        ToolTipUtil.attachCustomTooltip(txtPassword, "Enter your password");
 
         // ⚠️ LOGIN VALIDATION LOGIC
-        loginBtn.addActionListener(e -> {
-            String userId = emailField.getText().trim();
-            String pwd    = new String(passwordField.getPassword()).trim();
+        cmdLogin.addActionListener(e -> {
+            String userId = txtEmailField.getText().trim();
+            String pwd    = new String(txtPassword.getPassword()).trim();
 
             // 1) Validate empty fields
             boolean valid = true;
             if (userId.isEmpty()) {
-                emailField.setValidationBorderColor(Color.RED);
+                txtEmailField.setValidationBorderColor(Color.RED);
                 valid = false;
             } else {
-                emailField.setValidationBorderColor(Color.GRAY);
+                txtEmailField.setValidationBorderColor(Color.GRAY);
             }
             if (pwd.isEmpty()) {
-                passwordField.setValidationBorderColor(Color.RED);
+                txtPassword.setValidationBorderColor(Color.RED);
                 valid = false;
             } else {
-                passwordField.setValidationBorderColor(Color.GRAY);
+                txtPassword.setValidationBorderColor(Color.GRAY);
             }
             if (!valid) {
                 CustomDialogUtil.showStyledErrorDialog(
@@ -197,27 +197,27 @@ public class LoginPage extends JFrame {
         });
                 
 
-        JLabel forgotLabel = new JLabel("<html><div style='color:#7E4CA5;font-weight:600;'>Forgotten your password?</div></html>");
-        forgotLabel.setFont(FontUtil.getOutfitFont(16f));
-        forgotLabel.setBounds(679, yPosi + 195 + 3, 200, 30);
-        forgotLabel.setCursor(new Cursor(Cursor.HAND_CURSOR));
-        background.add(forgotLabel);
+        JLabel lblForgot = new JLabel("<html><div style='color:#7E4CA5;font-weight:600;'>Forgotten your password?</div></html>");
+        lblForgot.setFont(FontUtil.getOutfitFont(16f));
+        lblForgot.setBounds(679, intYPos + 195 + 3, 200, 30);
+        lblForgot.setCursor(new Cursor(Cursor.HAND_CURSOR));
+        pnlBackground.add(lblForgot);
 
-        JCheckBox keepSignedIn = new JCheckBox("Keep me signed in");
-        keepSignedIn.setFont(FontUtil.getOutfitFont(16f));
-        keepSignedIn.setForeground(new Color(140, 140, 140));
-        keepSignedIn.setOpaque(false);
-        keepSignedIn.setFocusPainted(false);
-        keepSignedIn.setBorderPainted(false);
-        keepSignedIn.setContentAreaFilled(false);
+        JCheckBox chkKeepSignedIn = new JCheckBox("Keep me signed in");
+        chkKeepSignedIn.setFont(FontUtil.getOutfitFont(16f));
+        chkKeepSignedIn.setForeground(new Color(140, 140, 140));
+        chkKeepSignedIn.setOpaque(false);
+        chkKeepSignedIn.setFocusPainted(false);
+        chkKeepSignedIn.setBorderPainted(false);
+        chkKeepSignedIn.setContentAreaFilled(false);
 
-        keepSignedIn.setIcon(new ImageIcon(getClass().getClassLoader().getResource("icons/checkbox_unchecked.png")));
-        keepSignedIn.setSelectedIcon(new ImageIcon(getClass().getClassLoader().getResource("icons/checkbox_checked.png")));
+        chkKeepSignedIn.setIcon(new ImageIcon(getClass().getClassLoader().getResource("icons/checkbox_unchecked.png")));
+        chkKeepSignedIn.setSelectedIcon(new ImageIcon(getClass().getClassLoader().getResource("icons/checkbox_checked.png")));
 
-        keepSignedIn.setBounds(523, yPosi + 195 + 45, 250, 40);
-        background.add(keepSignedIn);
+        chkKeepSignedIn.setBounds(523, intYPos + 195 + 45, 250, 40);
+        pnlBackground.add(chkKeepSignedIn);
 
-        SwingUtilities.invokeLater(() -> background.requestFocusInWindow());
+        SwingUtilities.invokeLater(() -> pnlBackground.requestFocusInWindow());
     }
 
     public static void main(String[] args) {

--- a/application-system/src/main/java/com/group_9/project/PlansPage.java
+++ b/application-system/src/main/java/com/group_9/project/PlansPage.java
@@ -12,10 +12,10 @@ public class PlansPage extends JFrame {
         BaseFrameSetup.applyAppIcon(this);
         BaseFrameSetup.setupFrame(this);
 
-        JPanel mainContainer = new JPanel();
-        mainContainer.setLayout(new BoxLayout(mainContainer, BoxLayout.Y_AXIS));
+        JPanel pnlMainContainer = new JPanel();
+        pnlMainContainer.setLayout(new BoxLayout(pnlMainContainer, BoxLayout.Y_AXIS));
 
-        BackgroundPanel navbarPanel = new BackgroundPanel(4) {
+        BackgroundPanel pnlNavbar = new BackgroundPanel(4) {
             @Override
             protected void paintComponent(Graphics g) {
                 Graphics2D g2d = (Graphics2D) g;
@@ -23,97 +23,97 @@ public class PlansPage extends JFrame {
                 g2d.fillRect(0, 0, getWidth(), getHeight());
             }
         };
-        navbarPanel.setLayout(null);
-        navbarPanel.setPreferredSize(new Dimension(1440, 80));
-        navbarPanel.setMaximumSize(new Dimension(Integer.MAX_VALUE, 80));
-        navbarPanel.setMinimumSize(new Dimension(1440, 80));
+        pnlNavbar.setLayout(null);
+        pnlNavbar.setPreferredSize(new Dimension(1440, 80));
+        pnlNavbar.setMaximumSize(new Dimension(Integer.MAX_VALUE, 80));
+        pnlNavbar.setMinimumSize(new Dimension(1440, 80));
 
-        BaseFrameSetup.createLogo(navbarPanel);
-        BaseFrameSetup.createNavigation(navbarPanel, this);
-        BaseFrameSetup.createLoginButton(navbarPanel, this);
+        BaseFrameSetup.createLogo(pnlNavbar);
+        BaseFrameSetup.createNavigation(pnlNavbar, this);
+        BaseFrameSetup.createLoginButton(pnlNavbar, this);
 
-        BackgroundPanel contentBackground = BaseFrameSetup.createBackgroundPanel(2);
-        contentBackground.setLayout(new BoxLayout(contentBackground, BoxLayout.Y_AXIS));
-        contentBackground.setPreferredSize(new Dimension(1440, 1100));
-        contentBackground.setBorder(BorderFactory.createEmptyBorder(50, 0, 50, 0));
+        BackgroundPanel pnlContentBackground = BaseFrameSetup.createBackgroundPanel(2);
+        pnlContentBackground.setLayout(new BoxLayout(pnlContentBackground, BoxLayout.Y_AXIS));
+        pnlContentBackground.setPreferredSize(new Dimension(1440, 1100));
+        pnlContentBackground.setBorder(BorderFactory.createEmptyBorder(50, 0, 50, 0));
 
-        JLabel title = new JLabel("Power Your Experience Your Way");
-        title.setFont(FontUtil.getOutfitBoldFont(50f));
-        title.setAlignmentX(Component.CENTER_ALIGNMENT);
-        title.setForeground(Color.decode("#2B0243"));
-        contentBackground.add(title);
-        contentBackground.add(Box.createRigidArea(new Dimension(0, 16)));
+        JLabel lblTitle = new JLabel("Power Your Experience Your Way");
+        lblTitle.setFont(FontUtil.getOutfitBoldFont(50f));
+        lblTitle.setAlignmentX(Component.CENTER_ALIGNMENT);
+        lblTitle.setForeground(Color.decode("#2B0243"));
+        pnlContentBackground.add(lblTitle);
+        pnlContentBackground.add(Box.createRigidArea(new Dimension(0, 16)));
 
-        JLabel note = new JLabel("Start with what you need, add more when you're ready.");
-        note.setFont(FontUtil.getInterFont(16f));
-        note.setAlignmentX(Component.CENTER_ALIGNMENT);
-        note.setForeground(Color.decode("#2B0243"));
-        contentBackground.add(note);
-        contentBackground.add(Box.createRigidArea(new Dimension(0, 58)));
+        JLabel lblNote = new JLabel("Start with what you need, add more when you're ready.");
+        lblNote.setFont(FontUtil.getInterFont(16f));
+        lblNote.setAlignmentX(Component.CENTER_ALIGNMENT);
+        lblNote.setForeground(Color.decode("#2B0243"));
+        pnlContentBackground.add(lblNote);
+        pnlContentBackground.add(Box.createRigidArea(new Dimension(0, 58)));
 
-        createPlansSection(contentBackground);
+        createPlansSection(pnlContentBackground);
 
-        JScrollPane scrollPane = new JScrollPane(contentBackground);
-        scrollPane.setVerticalScrollBarPolicy(JScrollPane.VERTICAL_SCROLLBAR_AS_NEEDED);
-        scrollPane.setHorizontalScrollBarPolicy(JScrollPane.HORIZONTAL_SCROLLBAR_NEVER);
-        scrollPane.getVerticalScrollBar().setUnitIncrement(16);
-        scrollPane.setBorder(null);
+        JScrollPane scrContent = new JScrollPane(pnlContentBackground);
+        scrContent.setVerticalScrollBarPolicy(JScrollPane.VERTICAL_SCROLLBAR_AS_NEEDED);
+        scrContent.setHorizontalScrollBarPolicy(JScrollPane.HORIZONTAL_SCROLLBAR_NEVER);
+        scrContent.getVerticalScrollBar().setUnitIncrement(16);
+        scrContent.setBorder(null);
 
-        JScrollBar verticalScrollBar = scrollPane.getVerticalScrollBar();
-        verticalScrollBar.setUI(new CustomScrollBarUI());
-        verticalScrollBar.setOpaque(false);
-        verticalScrollBar.setPreferredSize(new Dimension(10, 0));
+        JScrollBar sbVertical = scrContent.getVerticalScrollBar();
+        sbVertical.setUI(new CustomScrollBarUI());
+        sbVertical.setOpaque(false);
+        sbVertical.setPreferredSize(new Dimension(10, 0));
 
-        mainContainer.add(navbarPanel);
-        mainContainer.add(scrollPane);
+        pnlMainContainer.add(pnlNavbar);
+        pnlMainContainer.add(scrContent);
 
-        setContentPane(mainContainer);
+        setContentPane(pnlMainContainer);
         setVisible(true);
     }
 
-    private void createPlansSection(BackgroundPanel contentBackground) {
-        JPanel firstRowPanel = createPlansRow();
-        firstRowPanel.add(createPlanCard("FIBERX 1500", "P1500", "/month",
+    private void createPlansSection(BackgroundPanel pnlContentBackground) {
+        JPanel pnlFirstRow = createPlansRow();
+        pnlFirstRow.add(createPlanCard("FIBERX 1500", "P1500", "/month",
                 "Installation Fee: P125/24mo.",
                 "Seamless streaming with blazing fast, ready to surf the web at lightning speed with our 4tra boosted 300Mbps internet plan - fast, reliable, and pocket friendly.",
                 "One Month Advance Payment"));
-        firstRowPanel.add(Box.createRigidArea(new Dimension(20, 0)));
-        firstRowPanel.add(createPlanCard("FIBERX 2500", "P2500", "/month",
+        pnlFirstRow.add(Box.createRigidArea(new Dimension(20, 0)));
+        pnlFirstRow.add(createPlanCard("FIBERX 2500", "P2500", "/month",
                 "Installation Fee: P125/24mo.",
                 "Ultra-HD streaming and faster uploads. Enjoy uninterrupted video calls, 4K streaming, and file transfers with our 500Mbps boosted plan.",
                 "One Month Advance Payment"));
-        firstRowPanel.add(Box.createRigidArea(new Dimension(20, 0)));
-        firstRowPanel.add(createPlanCard("FIBERX 3500", "P3500", "/month",
+        pnlFirstRow.add(Box.createRigidArea(new Dimension(20, 0)));
+        pnlFirstRow.add(createPlanCard("FIBERX 3500", "P3500", "/month",
                 "Installation Fee: P125/24mo.",
                 "Power without limits. Our robust 700Mbps speed delivers seamless streaming, fast downloads, and reliable performance for work and play.",
                 "One Month Advance Payment"));
-        contentBackground.add(firstRowPanel);
-        contentBackground.add(Box.createRigidArea(new Dimension(0, 30)));
+        pnlContentBackground.add(pnlFirstRow);
+        pnlContentBackground.add(Box.createRigidArea(new Dimension(0, 30)));
 
-        JPanel secondRowPanel = createPlansRow();
-        secondRowPanel.add(createPlanCard("FIBER Xtreme 4500", "P4500", "/month",
+        JPanel pnlSecondRow = createPlansRow();
+        pnlSecondRow.add(createPlanCard("FIBER Xtreme 4500", "P4500", "/month",
                 "Installation Fee: WAIVED",
                 "Unleash enterprise-level speed at home. Enjoy blazing 1Gbps internet with zero interruptions - ideal for smart homes and high-demand digital lifestyles.",
                 "Two Months Advance Payment"));
-        secondRowPanel.add(Box.createRigidArea(new Dimension(20, 0)));
-        secondRowPanel.add(createPlanCard("FIBER Xtreme 7000", "P7000", "/month",
+        pnlSecondRow.add(Box.createRigidArea(new Dimension(20, 0)));
+        pnlSecondRow.add(createPlanCard("FIBER Xtreme 7000", "P7000", "/month",
                 "Installation Fee: WAIVED",
                 "Unparalleled 2Gbps speed designed for high-tech homes and digital studios. Enjoy ultra-low latency, zero downtime, and massive bandwidth.",
                 "Two Months Advance Payment"));
-        secondRowPanel.add(Box.createRigidArea(new Dimension(20, 0)));
-        secondRowPanel.add(Box.createRigidArea(new Dimension(375, 413)));
+        pnlSecondRow.add(Box.createRigidArea(new Dimension(20, 0)));
+        pnlSecondRow.add(Box.createRigidArea(new Dimension(375, 413)));
 
-        contentBackground.add(secondRowPanel);
+        pnlContentBackground.add(pnlSecondRow);
     }
 
     private JPanel createPlansRow() {
-        JPanel row = new JPanel();
-        row.setLayout(new BoxLayout(row, BoxLayout.X_AXIS));
-        row.setOpaque(false);
-        row.setAlignmentX(Component.CENTER_ALIGNMENT);
-        row.setMaximumSize(new Dimension(1175, 413));
-        row.add(Box.createHorizontalGlue());
-        return row;
+        JPanel pnlRow = new JPanel();
+        pnlRow.setLayout(new BoxLayout(pnlRow, BoxLayout.X_AXIS));
+        pnlRow.setOpaque(false);
+        pnlRow.setAlignmentX(Component.CENTER_ALIGNMENT);
+        pnlRow.setMaximumSize(new Dimension(1175, 413));
+        pnlRow.add(Box.createHorizontalGlue());
+        return pnlRow;
     }
 
     private JPanel createPlanCard(
@@ -124,81 +124,81 @@ public class PlansPage extends JFrame {
             String description,
             String upfrontFee
     ) {
-        JPanel card = new JPanel();
-        card.setLayout(new BoxLayout(card, BoxLayout.Y_AXIS));
-        card.setPreferredSize(new Dimension(375, 413));
-        card.setOpaque(false);
-        card.setBorder(BorderFactory.createCompoundBorder(
+        JPanel pnlCard = new JPanel();
+        pnlCard.setLayout(new BoxLayout(pnlCard, BoxLayout.Y_AXIS));
+        pnlCard.setPreferredSize(new Dimension(375, 413));
+        pnlCard.setOpaque(false);
+        pnlCard.setBorder(BorderFactory.createCompoundBorder(
                 new RoundedComponents.RoundedBorder(15),
                 BorderFactory.createEmptyBorder(10, 10, 10, 10)));
 
-        JLabel nameLabel = new JLabel(planName);
-        nameLabel.setFont(FontUtil.getOutfitBoldFont(18f));
-        nameLabel.setForeground(Color.decode("#402F84"));
-        nameLabel.setAlignmentX(Component.LEFT_ALIGNMENT);
-        card.add(nameLabel);
-        card.add(Box.createRigidArea(new Dimension(0, 10)));
+        JLabel lblName = new JLabel(planName);
+        lblName.setFont(FontUtil.getOutfitBoldFont(18f));
+        lblName.setForeground(Color.decode("#402F84"));
+        lblName.setAlignmentX(Component.LEFT_ALIGNMENT);
+        pnlCard.add(lblName);
+        pnlCard.add(Box.createRigidArea(new Dimension(0, 10)));
 
-        JPanel pricePanel = new JPanel();
-        pricePanel.setLayout(new BoxLayout(pricePanel, BoxLayout.X_AXIS));
-        pricePanel.setOpaque(false);
-        pricePanel.setAlignmentX(Component.LEFT_ALIGNMENT);
-        pricePanel.add(new JLabel(price) {{
+        JPanel pnlPrice = new JPanel();
+        pnlPrice.setLayout(new BoxLayout(pnlPrice, BoxLayout.X_AXIS));
+        pnlPrice.setOpaque(false);
+        pnlPrice.setAlignmentX(Component.LEFT_ALIGNMENT);
+        pnlPrice.add(new JLabel(price) {{
             setFont(FontUtil.getOutfitBoldFont(50f));
             setForeground(Color.decode("#1E1E1E"));
         }});
-        pricePanel.add(new JLabel(period) {{
+        pnlPrice.add(new JLabel(period) {{
             setFont(FontUtil.getInterFont(16f));
             setForeground(Color.decode("#1E1E1E"));
             setBorder(BorderFactory.createEmptyBorder(5, 5, 0, 0));
         }});
-        card.add(pricePanel);
+        pnlCard.add(pnlPrice);
 
-        card.add(Box.createRigidArea(new Dimension(0, 10)));
-        card.add(new JLabel(installationFee) {{
+        pnlCard.add(Box.createRigidArea(new Dimension(0, 10)));
+        pnlCard.add(new JLabel(installationFee) {{
             setFont(FontUtil.getInterFont(16f));
             setForeground(Color.decode("#1E1E1E"));
             setAlignmentX(Component.LEFT_ALIGNMENT);
         }});
-        card.add(Box.createRigidArea(new Dimension(0, 10)));
+        pnlCard.add(Box.createRigidArea(new Dimension(0, 10)));
 
-        JTextArea descArea = new JTextArea(description);
-        descArea.setFont(FontUtil.getInterFont(16f));
-        descArea.setForeground(Color.decode("#1E1E1E"));
-        descArea.setOpaque(false);
-        descArea.setEditable(false);
-        descArea.setLineWrap(true);
-        descArea.setWrapStyleWord(true);
-        descArea.setAlignmentX(Component.LEFT_ALIGNMENT);
-        card.add(descArea);
+        JTextArea txtaDesc = new JTextArea(description);
+        txtaDesc.setFont(FontUtil.getInterFont(16f));
+        txtaDesc.setForeground(Color.decode("#1E1E1E"));
+        txtaDesc.setOpaque(false);
+        txtaDesc.setEditable(false);
+        txtaDesc.setLineWrap(true);
+        txtaDesc.setWrapStyleWord(true);
+        txtaDesc.setAlignmentX(Component.LEFT_ALIGNMENT);
+        pnlCard.add(txtaDesc);
 
-        card.add(Box.createVerticalGlue());
-        card.add(Box.createRigidArea(new Dimension(0, 10)));
+        pnlCard.add(Box.createVerticalGlue());
+        pnlCard.add(Box.createRigidArea(new Dimension(0, 10)));
 
-        card.add(new JLabel("Required Upfront Fee:") {{
+        pnlCard.add(new JLabel("Required Upfront Fee:") {{
             setFont(FontUtil.getInterFont(16f).deriveFont(Font.BOLD));
             setForeground(Color.decode("#1E1E1E"));
             setAlignmentX(Component.LEFT_ALIGNMENT);
         }});
-        card.add(new JLabel(upfrontFee) {{
+        pnlCard.add(new JLabel(upfrontFee) {{
             setFont(FontUtil.getInterFont(16f));
             setForeground(Color.decode("#1E1E1E"));
             setAlignmentX(Component.LEFT_ALIGNMENT);
         }});
-        card.add(Box.createRigidArea(new Dimension(0, 15)));
+        pnlCard.add(Box.createRigidArea(new Dimension(0, 15)));
 
         // ——— HERE: wire GET PLAN to SignUp1 ———
-        JPanel buttonPanel = new JPanel(new FlowLayout(FlowLayout.CENTER));
-        buttonPanel.setOpaque(false);
-        RoundedComponents.RoundedButton nextButton =
+        JPanel pnlButton = new JPanel(new FlowLayout(FlowLayout.CENTER));
+        pnlButton.setOpaque(false);
+        RoundedComponents.RoundedButton cmdNextButton =
             new RoundedComponents.RoundedButton("GET PLAN", 25);
-        nextButton.setPreferredSize(new Dimension(186, 39));
-        nextButton.setBackground(Color.decode("#2A0243"));
-        nextButton.setForeground(Color.WHITE);
-        nextButton.setFont(FontUtil.getOutfitBoldFont(16f));
-        nextButton.setBorderColor(Color.decode("#2A0243"));
+        cmdNextButton.setPreferredSize(new Dimension(186, 39));
+        cmdNextButton.setBackground(Color.decode("#2A0243"));
+        cmdNextButton.setForeground(Color.WHITE);
+        cmdNextButton.setFont(FontUtil.getOutfitBoldFont(16f));
+        cmdNextButton.setBorderColor(Color.decode("#2A0243"));
         // on click → go to SignUp1
-        nextButton.addActionListener(e -> {
+        cmdNextButton.addActionListener(e -> {
             String appNo = UserApplicationData.get("ApplicationNo");
             if (appNo != null && !appNo.isEmpty()) {
                 new AddPlansPage().setVisible(true);
@@ -207,10 +207,10 @@ public class PlansPage extends JFrame {
             }
             dispose();
         });
-        buttonPanel.add(nextButton);
-        card.add(buttonPanel);
+        pnlButton.add(cmdNextButton);
+        pnlCard.add(pnlButton);
 
-        return card;
+        return pnlCard;
     }
 
 

--- a/application-system/src/main/java/com/group_9/project/Template.java
+++ b/application-system/src/main/java/com/group_9/project/Template.java
@@ -10,7 +10,7 @@ public class Template extends JFrame {
 
     public Template() {
         BaseFrameSetup.applyAppIcon(this);
-        BackgroundPanel background = BaseFrameSetup.setupCompleteFrame(this, 1);
+        BackgroundPanel pnlBackground = BaseFrameSetup.setupCompleteFrame(this, 1);
         
     }
 

--- a/application-system/src/main/java/com/group_9/project/TrackingPage.java
+++ b/application-system/src/main/java/com/group_9/project/TrackingPage.java
@@ -16,112 +16,112 @@ public class TrackingPage extends JFrame {
 
     public TrackingPage() {
         BaseFrameSetup.applyAppIcon(this);
-        BackgroundPanel background = BaseFrameSetup.setupCompleteFrame(this, 1);
+        BackgroundPanel pnlBackground = BaseFrameSetup.setupCompleteFrame(this, 1);
 
         // ─── Headline & Subheadline ───────────────────────────────────────────────
-        JLabel headline = new JLabel(
+        JLabel lblHeadline = new JLabel(
             "<html><div style='text-align:center;color:#2B0243;font-weight:700;'>"
           + "Supercharge your home with<br>ultra-fast internet and endless entertainment."
           + "</div></html>",
             SwingConstants.CENTER
         );
-        headline.setFont(FontUtil.getOutfitFont(50f));
-        headline.setForeground(new Color(0x2B0243));
-        headline.setBounds(112, 220, 1200, 120);
-        background.add(headline);
+        lblHeadline.setFont(FontUtil.getOutfitFont(50f));
+        lblHeadline.setForeground(new Color(0x2B0243));
+        lblHeadline.setBounds(112, 220, 1200, 120);
+        pnlBackground.add(lblHeadline);
 
-        JLabel subHeadline = new JLabel(
+        JLabel lblSubHeadline = new JLabel(
             "Enjoy faster speed, and incredible value with our plans.",
             SwingConstants.CENTER
         );
-        subHeadline.setFont(FontUtil.getInterFont(16f));
-        subHeadline.setBounds(420, 350, 600, 30);
-        background.add(subHeadline);
+        lblSubHeadline.setFont(FontUtil.getInterFont(16f));
+        lblSubHeadline.setBounds(420, 350, 600, 30);
+        pnlBackground.add(lblSubHeadline);
 
         // ─── CTA Buttons ─────────────────────────────────────────────────────────
-        JButton viewPlans = new JButton("VIEW PLANS");
-        viewPlans.setFont(FontUtil.getOutfitFont(16f).deriveFont(Font.BOLD));
-        viewPlans.setBounds(530, 400, 160, 45);
-        viewPlans.setFocusPainted(false);
+        JButton cmdViewPlans = new JButton("VIEW PLANS");
+        cmdViewPlans.setFont(FontUtil.getOutfitFont(16f).deriveFont(Font.BOLD));
+        cmdViewPlans.setBounds(530, 400, 160, 45);
+        cmdViewPlans.setFocusPainted(false);
         ButtonHoverEffect.apply(
-            viewPlans,
+            cmdViewPlans,
             new Color(62, 10, 118), Color.WHITE,
             new Color(42, 2, 67),  Color.WHITE,
             new Color(62, 10, 118), new Color(42, 2, 67)
         );
-        viewPlans.addActionListener(e -> { new PlansPage().setVisible(true); dispose(); });
-        background.add(viewPlans);
+        cmdViewPlans.addActionListener(e -> { new PlansPage().setVisible(true); dispose(); });
+        pnlBackground.add(cmdViewPlans);
 
-        JButton checkAvail = new JButton("CHECK AVAILABILITY");
-        checkAvail.setFont(FontUtil.getOutfitFont(16f).deriveFont(Font.BOLD));
-        checkAvail.setBounds(700, 400, 220, 45);
-        checkAvail.setFocusPainted(false);
-        checkAvail.setContentAreaFilled(false);
+        JButton cmdCheckAvail = new JButton("CHECK AVAILABILITY");
+        cmdCheckAvail.setFont(FontUtil.getOutfitFont(16f).deriveFont(Font.BOLD));
+        cmdCheckAvail.setBounds(700, 400, 220, 45);
+        cmdCheckAvail.setFocusPainted(false);
+        cmdCheckAvail.setContentAreaFilled(false);
         ButtonHoverEffect.apply(
-            checkAvail,
+            cmdCheckAvail,
             new Color(62, 10, 118), new Color(62, 10, 118),
             new Color(0,0,0,0),    new Color(38,6,67),
             new Color(62,10,118),  new Color(42,2,67)
         );
-        checkAvail.addActionListener(e -> { new ErrorPage().setVisible(true); dispose(); });
-        background.add(checkAvail);
+        cmdCheckAvail.addActionListener(e -> { new ErrorPage().setVisible(true); dispose(); });
+        pnlBackground.add(cmdCheckAvail);
 
         // ─── WiFi Icon ───────────────────────────────────────────────────────────
         ImageIcon wifiRaw = new ImageIcon(
             getClass().getClassLoader().getResource("images/wifi.png")
         );
         Image wifiImg2 = wifiRaw.getImage().getScaledInstance(200, 200, Image.SCALE_SMOOTH);
-        JLabel wifiLabel = new JLabel(new ImageIcon(wifiImg2));
-        wifiLabel.setBounds(302, 495, 200, 200);
-        background.add(wifiLabel);
+        JLabel lblWifi = new JLabel(new ImageIcon(wifiImg2));
+        lblWifi.setBounds(302, 495, 200, 200);
+        pnlBackground.add(lblWifi);
 
         // ─── Upgrade CTA ─────────────────────────────────────────────────────────
         int xLeft = 140, yLeft = 780;
-        JLabel upgradeTitle = new JLabel(
+        JLabel lblUpgradeTitle = new JLabel(
             "<html><div style='text-align:left;color:#2B0243;font-weight:700;'>"
           + "Ready to Upgrade Your Setup?</div></html>"
         );
-        upgradeTitle.setFont(FontUtil.getInterFont(35f));
-        upgradeTitle.setForeground(new Color(43, 2, 67));
-        upgradeTitle.setBounds(xLeft, yLeft - 50, 600, 45);
-        background.add(upgradeTitle);
+        lblUpgradeTitle.setFont(FontUtil.getInterFont(35f));
+        lblUpgradeTitle.setForeground(new Color(43, 2, 67));
+        lblUpgradeTitle.setBounds(xLeft, yLeft - 50, 600, 45);
+        pnlBackground.add(lblUpgradeTitle);
 
-        JLabel upgradeDesc = new JLabel(
+        JLabel lblUpgradeDesc = new JLabel(
             "<html>Start with one, then add more plans as your<br>needs grow.</html>"
         );
-        upgradeDesc.setFont(FontUtil.getInterFont(16f));
-        upgradeDesc.setForeground(new Color(43, 2, 67));
-        upgradeDesc.setBounds(xLeft, yLeft, 450, 50);
-        background.add(upgradeDesc);
+        lblUpgradeDesc.setFont(FontUtil.getInterFont(16f));
+        lblUpgradeDesc.setForeground(new Color(43, 2, 67));
+        lblUpgradeDesc.setBounds(xLeft, yLeft, 450, 50);
+        pnlBackground.add(lblUpgradeDesc);
 
-        RoundedComponents.RoundedButton morePlans = new RoundedComponents.RoundedButton("GET MORE PLANS", 20);
-        morePlans.setFont(FontUtil.getOutfitFont(14f).deriveFont(Font.BOLD));
-        morePlans.setBounds(xLeft, yLeft + 60, 160, 40);
-        morePlans.setFocusPainted(false);
+        RoundedComponents.RoundedButton cmdMorePlans = new RoundedComponents.RoundedButton("GET MORE PLANS", 20);
+        cmdMorePlans.setFont(FontUtil.getOutfitFont(14f).deriveFont(Font.BOLD));
+        cmdMorePlans.setBounds(xLeft, yLeft + 60, 160, 40);
+        cmdMorePlans.setFocusPainted(false);
         ButtonHoverEffect.apply(
-            morePlans,
+            cmdMorePlans,
             new Color(62, 10, 118), Color.WHITE,
             new Color(42, 2, 67),  Color.WHITE,
             new Color(62, 10, 118), new Color(42, 2, 67)
         );
-        morePlans.addActionListener(e -> { new PlansPage().setVisible(true); dispose(); });
-        background.add(morePlans);
+        cmdMorePlans.addActionListener(e -> { new PlansPage().setVisible(true); dispose(); });
+        pnlBackground.add(cmdMorePlans);
 
         // ─────────────────────────────────────────────────────────────────────────
         // APPLICATION TRACKER panel (dynamic, one card per application)
         // ─────────────────────────────────────────────────────────────────────────
 
         // Title + search field
-        JLabel trackerTitle = new JLabel(
+        JLabel lblTrackerTitle = new JLabel(
           "<html><div style='color:#2A0243;font-weight:700;'>APPLICATION TRACKER</div></html>",
           SwingConstants.CENTER
         );
-        trackerTitle.setFont(FontUtil.getOutfitFont(26f));
+        lblTrackerTitle.setFont(FontUtil.getOutfitFont(26f));
 
-        RoundedComponents.RoundedTextField searchField =
+        RoundedComponents.RoundedTextField txtSearchField =
             new RoundedComponents.RoundedTextField("Enter application number", 20);
-        searchField.setFont(FontUtil.getInterFont(14f));
-        searchField.setBackground(Color.WHITE);
+        txtSearchField.setFont(FontUtil.getInterFont(14f));
+        txtSearchField.setBackground(Color.WHITE);
 
         // 1) Load all subscriptions (one per plan)
         String username = UserApplicationData.get("Username");
@@ -141,85 +141,85 @@ public class TrackingPage extends JFrame {
         List<Subscription> apps = new ArrayList<>(unique.values());
 
         // 3) Build cards container
-        JPanel cardsContainer = new JPanel();
-        cardsContainer.setLayout(new BoxLayout(cardsContainer, BoxLayout.Y_AXIS));
-        cardsContainer.setOpaque(false);
+        JPanel pnlCardsContainer = new JPanel();
+        pnlCardsContainer.setLayout(new BoxLayout(pnlCardsContainer, BoxLayout.Y_AXIS));
+        pnlCardsContainer.setOpaque(false);
 
         if (apps.isEmpty()) {
-            JLabel none = new JLabel("You have no applications to track.");
-            none.setFont(FontUtil.getOutfitFont(16f));
-            none.setForeground(new Color(80,80,80));
-            none.setAlignmentX(Component.CENTER_ALIGNMENT);
-            cardsContainer.add(Box.createVerticalGlue());
-            cardsContainer.add(none);
-            cardsContainer.add(Box.createVerticalGlue());
+            JLabel lblNone = new JLabel("You have no applications to track.");
+            lblNone.setFont(FontUtil.getOutfitFont(16f));
+            lblNone.setForeground(new Color(80,80,80));
+            lblNone.setAlignmentX(Component.CENTER_ALIGNMENT);
+            pnlCardsContainer.add(Box.createVerticalGlue());
+            pnlCardsContainer.add(lblNone);
+            pnlCardsContainer.add(Box.createVerticalGlue());
         } else {
             for (Subscription s : apps) {
-                RoundedGradientPanel card = new RoundedGradientPanel(20);
-                card.setLayout(null);
-                card.setPreferredSize(new Dimension(887, 90));
-                card.setMaximumSize(new Dimension(887, 90));
+                RoundedGradientPanel pnlCard = new RoundedGradientPanel(20);
+                pnlCard.setLayout(null);
+                pnlCard.setPreferredSize(new Dimension(887, 90));
+                pnlCard.setMaximumSize(new Dimension(887, 90));
 
-                JLabel appNumberLbl = new JLabel("Application No. " + s.applicationNo);
-                appNumberLbl.setFont(FontUtil.getOutfitFont(14f).deriveFont(Font.BOLD));
-                appNumberLbl.setForeground(Color.WHITE);
-                appNumberLbl.setBounds(20, 15, 300, 20);
-                card.add(appNumberLbl);
+                JLabel lblAppNumber = new JLabel("Application No. " + s.applicationNo);
+                lblAppNumber.setFont(FontUtil.getOutfitFont(14f).deriveFont(Font.BOLD));
+                lblAppNumber.setForeground(Color.WHITE);
+                lblAppNumber.setBounds(20, 15, 300, 20);
+                pnlCard.add(lblAppNumber);
 
-                JLabel appStatusLbl = new JLabel("Status: Pending");
-                appStatusLbl.setFont(FontUtil.getInterFont(12f));
-                appStatusLbl.setForeground(Color.WHITE);
-                appStatusLbl.setBounds(20, 38, 300, 18);
-                card.add(appStatusLbl);
+                JLabel lblAppStatus = new JLabel("Status: Pending");
+                lblAppStatus.setFont(FontUtil.getInterFont(12f));
+                lblAppStatus.setForeground(Color.WHITE);
+                lblAppStatus.setBounds(20, 38, 300, 18);
+                pnlCard.add(lblAppStatus);
 
-                JLabel appDateLbl = new JLabel("Date Submitted: " + s.dateSubmitted);
-                appDateLbl.setFont(FontUtil.getInterFont(12f));
-                appDateLbl.setForeground(Color.WHITE);
-                appDateLbl.setBounds(20, 58, 300, 18);
-                card.add(appDateLbl);
+                JLabel lblAppDate = new JLabel("Date Submitted: " + s.dateSubmitted);
+                lblAppDate.setFont(FontUtil.getInterFont(12f));
+                lblAppDate.setForeground(Color.WHITE);
+                lblAppDate.setBounds(20, 58, 300, 18);
+                pnlCard.add(lblAppDate);
 
-                JLabel viewSummary = new JLabel("<html><u>View Plan Summary</u></html>");
-                viewSummary.setFont(FontUtil.getInterFont(12f));
-                viewSummary.setForeground(Color.WHITE);
-                viewSummary.setCursor(Cursor.getPredefinedCursor(Cursor.HAND_CURSOR));
-                viewSummary.setBounds(250, 58, 130, 18);
-                card.add(viewSummary);
+                JLabel lblViewSummary = new JLabel("<html><u>View Plan Summary</u></html>");
+                lblViewSummary.setFont(FontUtil.getInterFont(12f));
+                lblViewSummary.setForeground(Color.WHITE);
+                lblViewSummary.setCursor(Cursor.getPredefinedCursor(Cursor.HAND_CURSOR));
+                lblViewSummary.setBounds(250, 58, 130, 18);
+                pnlCard.add(lblViewSummary);
 
-                cardsContainer.add(card);
-                cardsContainer.add(Box.createRigidArea(new Dimension(0, 15)));
+                pnlCardsContainer.add(pnlCard);
+                pnlCardsContainer.add(Box.createRigidArea(new Dimension(0, 15)));
             }
         }
 
         // 4) Wrap in scroll pane
-        JScrollPane scroll = new JScrollPane(
-            cardsContainer,
+        JScrollPane scrCards = new JScrollPane(
+            pnlCardsContainer,
             JScrollPane.VERTICAL_SCROLLBAR_AS_NEEDED,
             JScrollPane.HORIZONTAL_SCROLLBAR_NEVER
         );
-        scroll.setBorder(null);
-        scroll.setOpaque(false);
-        scroll.getViewport().setOpaque(false);
+        scrCards.setBorder(null);
+        scrCards.setOpaque(false);
+        scrCards.getViewport().setOpaque(false);
 
         // 5) Put everything in your tracker panel
-        RoundedPanel trackerPanel = new RoundedPanel(30) {
+        RoundedPanel pnlTracker = new RoundedPanel(30) {
             @Override public void doLayout() {
                 int pad = 20;
                 int w   = getWidth() - 2 * pad;
-                trackerTitle.setBounds(pad, 20, w, 30);
-                searchField .setBounds(pad, 60, w, 35);
-                scroll      .setBounds(pad, 110, w, getHeight() - 110 - pad);
+                lblTrackerTitle.setBounds(pad, 20, w, 30);
+                txtSearchField.setBounds(pad, 60, w, 35);
+                scrCards.setBounds(pad, 110, w, getHeight() - 110 - pad);
             }
         };
-        trackerPanel.setBackground(new Color(255, 255, 255, 180));
-        trackerPanel.setBounds(800, 515, 484, 350);
-        trackerPanel.setLayout(null);
+        pnlTracker.setBackground(new Color(255, 255, 255, 180));
+        pnlTracker.setBounds(800, 515, 484, 350);
+        pnlTracker.setLayout(null);
 
-        trackerPanel.add(trackerTitle);
-        trackerPanel.add(searchField);
-        trackerPanel.add(scroll);
-        background.add(trackerPanel);
+        pnlTracker.add(lblTrackerTitle);
+        pnlTracker.add(txtSearchField);
+        pnlTracker.add(scrCards);
+        pnlBackground.add(pnlTracker);
 
-        SwingUtilities.invokeLater(background::requestFocusInWindow);
+        SwingUtilities.invokeLater(pnlBackground::requestFocusInWindow);
     }
 
     public static void main(String[] args) {

--- a/application-system/src/main/java/com/group_9/project/utils/AccountNavigationUtil.java
+++ b/application-system/src/main/java/com/group_9/project/utils/AccountNavigationUtil.java
@@ -17,11 +17,11 @@ public final class AccountNavigationUtil {
      *
      * @param parentFrame the JFrame to dispose after navigation
      */
-    public static void openAccountPageByApplication(JFrame parentFrame) {
-        String appNo = UserApplicationData.get("ApplicationNo");
-        if (appNo == null || appNo.isEmpty()) {
+    public static void openAccountPageByApplication(JFrame frmParent) {
+        String strAppNo = UserApplicationData.get("ApplicationNo");
+        if (strAppNo == null || strAppNo.isEmpty()) {
             CustomDialogUtil.showStyledErrorDialog(
-                parentFrame,
+                frmParent,
                 "No Application",
                 "No application number found in session."
             );
@@ -29,45 +29,45 @@ public final class AccountNavigationUtil {
         }
 
         try {
-            var profile = AccountService.getCustomerInfoByApplication(appNo);
-            if (profile == null) {
+            var objProfile = AccountService.getCustomerInfoByApplication(strAppNo);
+            if (objProfile == null) {
                 CustomDialogUtil.showStyledErrorDialog(
-                    parentFrame,
+                    frmParent,
                     "Load Error",
-                    "No account found for application #" + appNo
+                    "No account found for application #" + strAppNo
                 );
                 return;
             }
 
             // Populate session with all needed fields
-            UserApplicationData.set("Username",        profile.username);
-            UserApplicationData.set("Password",        profile.password);
-            UserApplicationData.set("CustomerName",    profile.fullName);
-            UserApplicationData.set("Birthday",        profile.birthdate);
-            UserApplicationData.set("Gender",          profile.gender);
-            UserApplicationData.set("CivilStatus",     profile.civilStatus);
-            UserApplicationData.set("MaidenName",      profile.motherMn);
-            UserApplicationData.set("Spouse",          profile.spouseName != null ? profile.spouseName : "");
-            UserApplicationData.set("Nationality",     profile.nationality);
-            UserApplicationData.set("Email",           profile.emailAdd);
-            UserApplicationData.set("Mobile",          profile.contactNo);
-            UserApplicationData.set("HomeOwnership",   profile.residenceType);
-            UserApplicationData.set("YearsOfResidency",String.valueOf(profile.residenceYrs));
-            UserApplicationData.set("CompanyPaid",     profile.compPaid);
-            UserApplicationData.set("NameOfOwner",     profile.ownerName);
-            UserApplicationData.set("ContactNumber",   profile.ownerContact);
-            UserApplicationData.set("ResidenceAddress",profile.residenceAdd);
+            UserApplicationData.set("Username",        objProfile.username);
+            UserApplicationData.set("Password",        objProfile.password);
+            UserApplicationData.set("CustomerName",    objProfile.fullName);
+            UserApplicationData.set("Birthday",        objProfile.birthdate);
+            UserApplicationData.set("Gender",          objProfile.gender);
+            UserApplicationData.set("CivilStatus",     objProfile.civilStatus);
+            UserApplicationData.set("MaidenName",      objProfile.motherMn);
+            UserApplicationData.set("Spouse",          objProfile.spouseName != null ? objProfile.spouseName : "");
+            UserApplicationData.set("Nationality",     objProfile.nationality);
+            UserApplicationData.set("Email",           objProfile.emailAdd);
+            UserApplicationData.set("Mobile",          objProfile.contactNo);
+            UserApplicationData.set("HomeOwnership",   objProfile.residenceType);
+            UserApplicationData.set("YearsOfResidency",String.valueOf(objProfile.residenceYrs));
+            UserApplicationData.set("CompanyPaid",     objProfile.compPaid);
+            UserApplicationData.set("NameOfOwner",     objProfile.ownerName);
+            UserApplicationData.set("ContactNumber",   objProfile.ownerContact);
+            UserApplicationData.set("ResidenceAddress",objProfile.residenceAdd);
 
             // Launch the details page
             new AccountDetailsPage().setVisible(true);
-            parentFrame.dispose();
+            frmParent.dispose();
 
         } catch (SQLException ex) {
             ex.printStackTrace();
             CustomDialogUtil.showStyledErrorDialog(
-                parentFrame,
+                frmParent,
                 "Database Error",
-                "Failed to load account details for application #" + appNo
+                "Failed to load account details for application #" + strAppNo
             );
         }
     }

--- a/application-system/src/main/java/com/group_9/project/utils/AccountSidebarUtil.java
+++ b/application-system/src/main/java/com/group_9/project/utils/AccountSidebarUtil.java
@@ -14,89 +14,89 @@ public final class AccountSidebarUtil {
     private static final Color DEFAULT_COLOR  = new Color(22, 6, 48, 128);
     private static final Color HOVER_COLOR    = new Color(62, 10, 118);
 
-    public static JPanel createSidebar(JFrame frame, String activeItem) {
-        JPanel sidebar = new JPanel();
-        sidebar.setLayout(new BoxLayout(sidebar, BoxLayout.Y_AXIS));
-        sidebar.setBounds(50, 125, 200, 300);
-        sidebar.setBackground(new Color(0, 0, 0, 0));
-        sidebar.setOpaque(false);
+    public static JPanel createSidebar(JFrame frmParent, String strActiveItem) {
+        JPanel pnlSidebar = new JPanel();
+        pnlSidebar.setLayout(new BoxLayout(pnlSidebar, BoxLayout.Y_AXIS));
+        pnlSidebar.setBounds(50, 125, 200, 300);
+        pnlSidebar.setBackground(new Color(0, 0, 0, 0));
+        pnlSidebar.setOpaque(false);
 
-        JLabel title = new JLabel("MY ACCOUNT");
-        title.setFont(FontUtil.getOutfitBoldFont(25f));
-        title.setForeground(new Color(42, 2, 67, 255));
-        title.setBorder(BorderFactory.createEmptyBorder(10, 10, 10, 10));
-        title.setOpaque(false);
-        sidebar.add(title);
-        sidebar.add(Box.createVerticalStrut(15));
+        JLabel lblTitle = new JLabel("MY ACCOUNT");
+        lblTitle.setFont(FontUtil.getOutfitBoldFont(25f));
+        lblTitle.setForeground(new Color(42, 2, 67, 255));
+        lblTitle.setBorder(BorderFactory.createEmptyBorder(10, 10, 10, 10));
+        lblTitle.setOpaque(false);
+        pnlSidebar.add(lblTitle);
+        pnlSidebar.add(Box.createVerticalStrut(15));
 
-        String[] items = {"My Details", "My Address", "My Subscriptions", "Sign Out"};
-        for (String item : items) {
-            Color color = item.equals(activeItem) ? SELECTED_COLOR : DEFAULT_COLOR;
-            JLabel label = createLabel("   " + item, color);
-            label.setCursor(Cursor.getPredefinedCursor(Cursor.HAND_CURSOR));
+        String[] arrItems = {"My Details", "My Address", "My Subscriptions", "Sign Out"};
+        for (String strItem : arrItems) {
+            Color colCurrent = strItem.equals(strActiveItem) ? SELECTED_COLOR : DEFAULT_COLOR;
+            JLabel lblOption = createLabel("   " + strItem, colCurrent);
+            lblOption.setCursor(Cursor.getPredefinedCursor(Cursor.HAND_CURSOR));
 
-            label.addMouseListener(new java.awt.event.MouseAdapter() {
+            lblOption.addMouseListener(new java.awt.event.MouseAdapter() {
                 @Override public void mouseClicked(java.awt.event.MouseEvent e) {
-                    switch (item) {
+                    switch (strItem) {
                         case "My Details" -> {
-                            if (!activeItem.equals("My Details")) {
+                            if (!strActiveItem.equals("My Details")) {
                                 SwingUtilities.invokeLater(() -> {
                                     new AccountDetailsPage().setVisible(true);
-                                    frame.dispose();
+                                    frmParent.dispose();
                                 });
                             }
                         }
                         case "My Address" -> {
-                            if (!activeItem.equals("My Address")) {
+                            if (!strActiveItem.equals("My Address")) {
                                 SwingUtilities.invokeLater(() -> {
                                     new AccountAddressPage().setVisible(true);
-                                    frame.dispose();
+                                    frmParent.dispose();
                                 });
                             }
                         }
                         case "My Subscriptions" -> {
-                            if (!activeItem.equals("My Subscriptions")) {
+                            if (!strActiveItem.equals("My Subscriptions")) {
                                 SwingUtilities.invokeLater(() -> {
                                     new AccountSubsPage().setVisible(true);
-                                    frame.dispose();
+                                    frmParent.dispose();
                                 });
                             }
                         }
                         case "Sign Out" -> {
                             boolean confirm = CustomDialogUtil.showStyledConfirmDialog(
-                                frame,
+                                frmParent,
                                 "Sign Out",
                                 "Are you sure you want to sign out?"
                             );
                             if (confirm) {
                                 UserApplicationData.clear();
                                 new Homepage().setVisible(true);
-                                frame.dispose();
+                                frmParent.dispose();
                             }
                         }
                     }
                 }
 
                 @Override public void mouseEntered(java.awt.event.MouseEvent e) {
-                    if (!item.equals(activeItem)) {
-                        label.setForeground(HOVER_COLOR);
-                        label.repaint();
+                    if (!strItem.equals(strActiveItem)) {
+                        lblOption.setForeground(HOVER_COLOR);
+                        lblOption.repaint();
                     }
                 }
 
                 @Override public void mouseExited(java.awt.event.MouseEvent e) {
-                    if (!item.equals(activeItem)) {
-                        label.setForeground(DEFAULT_COLOR);
-                        label.repaint();
+                    if (!strItem.equals(strActiveItem)) {
+                        lblOption.setForeground(DEFAULT_COLOR);
+                        lblOption.repaint();
                     }
                 }
             });
 
-            sidebar.add(label);
-            sidebar.add(Box.createVerticalStrut(30));
+            pnlSidebar.add(lblOption);
+            pnlSidebar.add(Box.createVerticalStrut(30));
         }
 
-        return sidebar;
+        return pnlSidebar;
     }
 
     private static JLabel createLabel(String text, Color color) {

--- a/application-system/src/main/java/com/group_9/project/utils/BackgroundPanel.java
+++ b/application-system/src/main/java/com/group_9/project/utils/BackgroundPanel.java
@@ -5,16 +5,16 @@ import java.awt.*;
 import java.net.URL;
 
 public class BackgroundPanel extends JPanel {
-    private Image backgroundImage;
+    private Image imgBackground;
 
-    public BackgroundPanel(int imageNumber) {
+    public BackgroundPanel(int intImageNumber) {
         try {
-            String imageName = "images/background" + imageNumber + ".png";
-            URL imageUrl = getClass().getClassLoader().getResource(imageName);
-            if (imageUrl != null) {
-                backgroundImage = new ImageIcon(imageUrl).getImage();
+            String strImageName = "images/background" + intImageNumber + ".png";
+            URL urlImage = getClass().getClassLoader().getResource(strImageName);
+            if (urlImage != null) {
+                imgBackground = new ImageIcon(urlImage).getImage();
             } else {
-                System.err.println("Background image not found: " + imageName);
+                System.err.println("Background image not found: " + strImageName);
             }
         } catch (Exception e) {
             e.printStackTrace();
@@ -24,8 +24,8 @@ public class BackgroundPanel extends JPanel {
     @Override
     protected void paintComponent(Graphics g) {
         super.paintComponent(g);
-        if (backgroundImage != null) {
-            g.drawImage(backgroundImage, 0, 0, getWidth(), getHeight(), this);
+        if (imgBackground != null) {
+            g.drawImage(imgBackground, 0, 0, getWidth(), getHeight(), this);
         }
     }
 }

--- a/application-system/src/main/java/com/group_9/project/utils/BaseFrameSetup.java
+++ b/application-system/src/main/java/com/group_9/project/utils/BaseFrameSetup.java
@@ -23,103 +23,103 @@ public class BaseFrameSetup {
     /**
      * Apply the application icon to the given frame.
      */
-    public static void applyAppIcon(JFrame frame) {
+    public static void applyAppIcon(JFrame frmTarget) {
         ImageIcon icon = new ImageIcon(
             BaseFrameSetup.class.getClassLoader().getResource("images/app_icon.png")
         );
-        frame.setIconImage(icon.getImage());
+        frmTarget.setIconImage(icon.getImage());
     }
 
 
-    public static void setupFrame(JFrame frame) {
-        frame.setTitle(WINDOW_TITLE);
-        frame.setSize(WINDOW_WIDTH, WINDOW_HEIGHT);
-        frame.setResizable(false);
-        frame.setLocationRelativeTo(null);
-        frame.setDefaultCloseOperation(JFrame.EXIT_ON_CLOSE);
-        frame.setLayout(null);
-    }
-    
-
-    public static BackgroundPanel createBackgroundPanel(int gradientType) {
-        BackgroundPanel background = new BackgroundPanel(gradientType);
-        background.setLayout(null);
-        return background;
+    public static void setupFrame(JFrame frmTarget) {
+        frmTarget.setTitle(WINDOW_TITLE);
+        frmTarget.setSize(WINDOW_WIDTH, WINDOW_HEIGHT);
+        frmTarget.setResizable(false);
+        frmTarget.setLocationRelativeTo(null);
+        frmTarget.setDefaultCloseOperation(JFrame.EXIT_ON_CLOSE);
+        frmTarget.setLayout(null);
     }
     
-    public static JLabel createLogo(BackgroundPanel background) {
+
+    public static BackgroundPanel createBackgroundPanel(int intGradientType) {
+        BackgroundPanel pnlBackground = new BackgroundPanel(intGradientType);
+        pnlBackground.setLayout(null);
+        return pnlBackground;
+    }
+    
+    public static JLabel createLogo(BackgroundPanel pnlBackground) {
         ImageIcon originalIcon = new ImageIcon(BaseFrameSetup.class.getClassLoader().getResource("images/converge_logo.png"));
         Image scaledImage = originalIcon.getImage().getScaledInstance(200, 70, Image.SCALE_SMOOTH);
         ImageIcon logoIcon = new ImageIcon(scaledImage);
-        
+
         JLabel logo = new JLabel(logoIcon);
         logo.setBounds(40, 30, 200, 44);
-        background.add(logo);
+        pnlBackground.add(logo);
         return logo;
     }
     
-    public static void createNavigation(BackgroundPanel background, JFrame currentFrame) {
-        String[] navItems = {"Home", "Plans", "Help & Support", "About Us"};
-        int xPos = 900;
-        int spacing = 30;
-        
-        for (String item : navItems) {
-            JLabel label = new JLabel(item);
-            label.setFont(FontUtil.getOutfitFont(16f));
-            label.setForeground(NAV_NORMAL_COLOR);
-            label.setCursor(Cursor.getPredefinedCursor(Cursor.HAND_CURSOR));
-            
-            label.addMouseListener(new java.awt.event.MouseAdapter() {
+    public static void createNavigation(BackgroundPanel pnlBackground, JFrame frmCurrent) {
+        String[] arrNavItems = {"Home", "Plans", "Help & Support", "About Us"};
+        int intXPos = 900;
+        int intSpacing = 30;
+
+        for (String strItem : arrNavItems) {
+            JLabel lblNav = new JLabel(strItem);
+            lblNav.setFont(FontUtil.getOutfitFont(16f));
+            lblNav.setForeground(NAV_NORMAL_COLOR);
+            lblNav.setCursor(Cursor.getPredefinedCursor(Cursor.HAND_CURSOR));
+
+            lblNav.addMouseListener(new java.awt.event.MouseAdapter() {
                 public void mouseEntered(java.awt.event.MouseEvent e) {
-                    label.setForeground(NAV_HOVER_COLOR);
+                    lblNav.setForeground(NAV_HOVER_COLOR);
                 }
-                
+
                 public void mouseExited(java.awt.event.MouseEvent e) {
-                    label.setForeground(NAV_NORMAL_COLOR);
+                    lblNav.setForeground(NAV_NORMAL_COLOR);
                 }
-                
+
                 public void mouseClicked(java.awt.event.MouseEvent e) {
-                    navigateToPage(item, currentFrame);
+                    navigateToPage(strItem, frmCurrent);
                 }
             });
-            
-            int textWidth = label.getPreferredSize().width;
-            label.setBounds(xPos, 30, textWidth + 10, 40);
-            background.add(label);
-            xPos += textWidth + spacing + 10;
+
+            int textWidth = lblNav.getPreferredSize().width;
+            lblNav.setBounds(intXPos, 30, textWidth + 10, 40);
+            pnlBackground.add(lblNav);
+            intXPos += textWidth + intSpacing + 10;
         }
     }
     
     // Fixed: Added currentFrame parameter to properly dispose of the current frame
-    public static JButton createLoginButton(BackgroundPanel background, JFrame currentFrame) {
-        String appNo = UserApplicationData.get("ApplicationNo");
-        if (appNo != null && !appNo.isEmpty()) {
-            JLabel accountLbl = new JLabel("Account");
-            accountLbl.setFont(FontUtil.getOutfitFont(16f));
-            accountLbl.setForeground(NAV_NORMAL_COLOR);
-            accountLbl.setCursor(Cursor.getPredefinedCursor(Cursor.HAND_CURSOR));
-            int w = accountLbl.getPreferredSize().width;
-            accountLbl.setBounds(1300, 30, w + 10, 40);
-            background.add(accountLbl);
+    public static JButton createLoginButton(BackgroundPanel pnlBackground, JFrame frmCurrent) {
+        String strAppNo = UserApplicationData.get("ApplicationNo");
+        if (strAppNo != null && !strAppNo.isEmpty()) {
+            JLabel lblAccount = new JLabel("Account");
+            lblAccount.setFont(FontUtil.getOutfitFont(16f));
+            lblAccount.setForeground(NAV_NORMAL_COLOR);
+            lblAccount.setCursor(Cursor.getPredefinedCursor(Cursor.HAND_CURSOR));
+            int intW = lblAccount.getPreferredSize().width;
+            lblAccount.setBounds(1300, 30, intW + 10, 40);
+            pnlBackground.add(lblAccount);
 
-            accountLbl.addMouseListener(new MouseAdapter() {
+            lblAccount.addMouseListener(new MouseAdapter() {
                 @Override public void mouseEntered(MouseEvent e) {
-                    accountLbl.setForeground(NAV_HOVER_COLOR);
+                    lblAccount.setForeground(NAV_HOVER_COLOR);
                 }
                 @Override public void mouseExited(MouseEvent e) {
-                    accountLbl.setForeground(NAV_NORMAL_COLOR);
+                    lblAccount.setForeground(NAV_NORMAL_COLOR);
                 }
 
                 @Override public void mouseClicked(MouseEvent e) {
-                    AccountNavigationUtil.openAccountPageByApplication(currentFrame);
+                    AccountNavigationUtil.openAccountPageByApplication(frmCurrent);
                     new AccountDetailsPage().setVisible(true);
-                    currentFrame.dispose();
+                    frmCurrent.dispose();
                 }
             });
             return null;
         } else {
             // Show "Log In"
-            RoundedComponents.RoundedButton loginBtn = 
+            RoundedComponents.RoundedButton loginBtn =
                 new RoundedComponents.RoundedButton("Log In", 20);
             loginBtn.setFont(FontUtil.getOutfitFont(16f).deriveFont(Font.BOLD));
             loginBtn.setBounds(1300, 30, 80, 35);
@@ -132,82 +132,82 @@ public class BaseFrameSetup {
             );
             loginBtn.addActionListener(ev -> {
                 new LoginPage().setVisible(true);
-                currentFrame.dispose();
+                frmCurrent.dispose();
             });
-            background.add(loginBtn);
+            pnlBackground.add(loginBtn);
             return loginBtn;
         }
     }
     
     // Fixed: Updated to pass currentFrame parameter to createLoginButton
-    public static BackgroundPanel setupCompleteFrame(JFrame frame, int gradientType) {
-        setupFrame(frame);
-        applyAppIcon(frame);
-        BackgroundPanel background = createBackgroundPanel(gradientType);
-        frame.setContentPane(background);
-        
-        createLogo(background);
-        createNavigation(background, frame);
-        createLoginButton(background, frame); 
-        
-        return background;
+    public static BackgroundPanel setupCompleteFrame(JFrame frmTarget, int intGradientType) {
+        setupFrame(frmTarget);
+        applyAppIcon(frmTarget);
+        BackgroundPanel pnlBackground = createBackgroundPanel(intGradientType);
+        frmTarget.setContentPane(pnlBackground);
+
+        createLogo(pnlBackground);
+        createNavigation(pnlBackground, frmTarget);
+        createLoginButton(pnlBackground, frmTarget);
+
+        return pnlBackground;
     }
     
-    private static void navigateToPage(String destination, JFrame currentFrame) {
-        switch (destination) {
+    private static void navigateToPage(String strDestination, JFrame frmCurrent) {
+        switch (strDestination) {
             case "Home" -> {
-                String appNo = UserApplicationData.get("ApplicationNo");
-                if (appNo != null && !appNo.isEmpty()) {
+                String strAppNo = UserApplicationData.get("ApplicationNo");
+                if (strAppNo != null && !strAppNo.isEmpty()) {
                     new TrackingPage().setVisible(true);
                 } else {
                     new Homepage().setVisible(true);
                 }
-                currentFrame.dispose();
+                frmCurrent.dispose();
             }
             case "Plans" -> {
                 new PlansPage().setVisible(true);
-                currentFrame.dispose();
+                frmCurrent.dispose();
             }
             case "Help & Support" -> {
                 new HelpSupportPage().setVisible(true);
-                currentFrame.dispose();
+                frmCurrent.dispose();
             }
             case "About Us" -> {
                 new AboutUsPage().setVisible(true);
-                currentFrame.dispose();
+                frmCurrent.dispose();
             }
         }
     }
     
-    public static void createCustomNavigation(BackgroundPanel background, JFrame currentFrame, 
-                                            String[] navItems, int startX) {
-        int xPos = startX;
-        int spacing = 30;
-        
-        for (String item : navItems) {
-            JLabel label = new JLabel(item);
-            label.setFont(FontUtil.getOutfitFont(16f));
-            label.setForeground(NAV_NORMAL_COLOR);
-            label.setCursor(Cursor.getPredefinedCursor(Cursor.HAND_CURSOR));
-            
-            label.addMouseListener(new java.awt.event.MouseAdapter() {
+    public static void createCustomNavigation(BackgroundPanel pnlBackground, JFrame frmCurrent,
+                                            String[] arrNavItems, int intStartX) {
+        int intXPos = intStartX;
+        int intSpacing = 30;
+
+        for (String strItem : arrNavItems) {
+            JLabel lblNav = new JLabel(strItem);
+            lblNav.setFont(FontUtil.getOutfitFont(16f));
+            lblNav.setForeground(NAV_NORMAL_COLOR);
+            lblNav.setCursor(Cursor.getPredefinedCursor(Cursor.HAND_CURSOR));
+
+            lblNav.addMouseListener(new java.awt.event.MouseAdapter() {
                 public void mouseEntered(java.awt.event.MouseEvent e) {
-                    label.setForeground(NAV_HOVER_COLOR);
+                    lblNav.setForeground(NAV_HOVER_COLOR);
                 }
-                
+
                 public void mouseExited(java.awt.event.MouseEvent e) {
-                    label.setForeground(NAV_NORMAL_COLOR);
+                    lblNav.setForeground(NAV_NORMAL_COLOR);
                 }
-                
+
                 public void mouseClicked(java.awt.event.MouseEvent e) {
-                    navigateToPage(item, currentFrame);
+                    navigateToPage(strItem, frmCurrent);
                 }
             });
-            
-            int textWidth = label.getPreferredSize().width;
-            label.setBounds(xPos, 30, textWidth + 10, 40);
-            background.add(label);
-            xPos += textWidth + spacing + 10;
+
+            int textWidth = lblNav.getPreferredSize().width;
+            lblNav.setBounds(intXPos, 30, textWidth + 10, 40);
+            pnlBackground.add(lblNav);
+            intXPos += textWidth + intSpacing + 10;
         }
     }
 }


### PR DESCRIPTION
## Summary
- rename variables in AddPlansPage to follow Reddick style
- update AccountNavigationUtil with prefixed identifiers
- refactor AccountSidebarUtil for consistent prefixes
- rename BackgroundPanel fields
- standardize BaseFrameSetup variable names

## Testing
- `mvn -q -DskipTests package` *(fails: mvn not found)*

------
https://chatgpt.com/codex/tasks/task_e_68583e3b5778832cb82e2315b86e2258